### PR TITLE
Ccp4Header --> consider path :mrc "decoration"

### DIFF
--- a/pwem/convert/headers.py
+++ b/pwem/convert/headers.py
@@ -116,7 +116,7 @@ class Ccp4Header:
     80-character 'lines' and the 'lines' do not terminate in a ``*``).
     """
     def __init__(self, fileName, readHeader=False):
-        self._name = fileName.replace(':mrc', '')  # remove mrc ending
+        self._name = self.cleanFileNameAnnotation(fileName)  # remove mrc ending
         self._header = collections.OrderedDict()
         self.chain = "< 3i i 3i 3i 3f 36s i 104s 3f"
 
@@ -125,6 +125,10 @@ class Ccp4Header:
             self.readHeader()
         else:
             self.loaded = False
+
+    @staticmethod
+    def cleanFileNameAnnotation(fileName):
+        return fileName.replace(':mrc', '')
 
     def setOrigin(self, originTransformShift):
         # TODO: should we use originX,Y,Z and set this to 0
@@ -264,9 +268,9 @@ class Ccp4Header:
         self._header['Xlength'] = a[10]
         self._header['Ylength'] = a[11]
         self._header['Zlength'] = a[12]
-        self._header['dummy1'] = a[13] + "\n"  # "< 3i i 3i 3i 3f 36s"
+        self._header['dummy1'] = a[13] + b"\n"  # "< 3i i 3i 3i 3f 36s"
         self._header['ISPG'] = a[14]
-        self._header['dummy2'] = a[15] + "\n"  # "< 3i i 3i 3i 3f 36s i 104s"
+        self._header['dummy2'] = a[15] + b"\n"  # "< 3i i 3i 3i 3f 36s i 104s"
         self._header['originX'] = a[16]
         self._header['originY'] = a[17]
         self._header['originZ'] = a[18]
@@ -331,7 +335,7 @@ class Ccp4Header:
     @classmethod
     def getFileFormat(cls, fileName):
 
-        ext = getExt(fileName)
+        ext = getExt(cls.cleanFileNameAnnotation(fileName))
         if (ext == '.mrc') or (ext == '.map'):
             return cls.MRC
         elif (ext == '.spi') or (ext == '.vol'):

--- a/pwem/convert/image_handler.py
+++ b/pwem/convert/image_handler.py
@@ -261,11 +261,20 @@ class ImageHandler(object):
             location = self._convertToLocation(locationObj)
             fn = location[1]
             ext = pwutils.getExt(fn).lower()
-            
+
+            # Local import to avoid import loop between ImageHandler and Ccp4Header.
+            from pwem.convert import Ccp4Header
+
             if ext == '.png' or ext == '.jpg':
                 im = PIL.Image.open(fn)
                 x, y = im.size # (width,height) tuple
                 return x, y, 1, 1
+
+            elif Ccp4Header.getFileFormat(fn) != Ccp4Header.UNKNOWNFORMAT:
+                header = Ccp4Header(fn, readHeader=True)
+                x, y, z = header.getDims()
+                return x, y, z, 1
+
             elif ext == '.img':
                 # FIXME Since now we can not read dm4 format in Scipion natively
                 # or recent .img format

--- a/pwem/xmipp-ghost/xmippLib.py
+++ b/pwem/xmipp-ghost/xmippLib.py
@@ -1061,14 +1061,27 @@ def MetaData():
 
 MetaDataInfo = None
 
-def Image():
-    pass
+HEADER = None
 
+class Image:
+    def __init__(self):
+        pass
+    def read(self, *args, **kwargs):
+        print ("GHOST in place, read call ignored!.")
+    def getDimensions(self):
+        return None, None, None, None
 def Euler_angles2matrix():
     pass
 
-def FileName(arg):
-    pass
+class FileName:
+    """ Try to implement some basic code to reach further without xmipp"""
+    imageExtentions = []
+
+    def __init__(self, path):
+        self.path = path
+
+    def isImage(self):
+        return True
 
 def getBlocksInMetaDataFile():
     pass


### PR DESCRIPTION
ImageHandler getDimensions: use ccp4header when possible
Ghost changes to reach further without xmipp.