### PR TITLE
modify maxit installation and fix bug related with filenames that contains spaces

### DIFF
--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -63,6 +63,10 @@ class Plugin(pyworkflow.plugin.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
+        cls.defineBinariesMaxit(False, env)
+
+    @classmethod
+    def defineBinariesMaxit(cls, default, env):
         MAXIT_URL = 'https://sw-tools.rcsb.org/apps/MAXIT/maxit-v10.100-prod-src.tar.gz'
         MAXIT_TAR = 'maxit-v10.100-prod-src.tar.gz'
         maxit_commands = [('make -j 1 binary ' , ['bin/maxit'])]
@@ -70,8 +74,8 @@ class Plugin(pyworkflow.plugin.Plugin):
                        tar=MAXIT_TAR,
                        url=MAXIT_URL,
                        commands=maxit_commands,
-                       default=False)  # scipion installb maxit
-                                       # requirements bison, flex, gcc
+                       default=default)  # scipion installb maxit
+                                         # requirements bison, flex, gcc
 
 
 Domain.registerPlugin(__name__)

--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from Bio.PDB.Polypeptide import is_aa
 from Bio.PDB.Polypeptide import three_to_one
 from Bio.Seq import Seq
-from pwem import Plugin
+from pwem import Plugin, MAXIT_HOME
 from pwem.convert.transformations import translation_from_matrix
 import mmap
 import re
@@ -741,7 +741,7 @@ def _frombase(inFileName, outFileName, log, oParam=1):
         # show error message
         print(pwutils.redStr("Please, install maxit with the command 'scipion installb maxit'"))
         print(pwutils.redStr("and restart scipion. Packages bison and flex are needed."))
-        print(pwutils.redStr("If maxit is installed check %s in scipion.conf" % MAXIT_HOME_LABEL))
+        print(pwutils.redStr("If maxit is installed check %s in scipion.conf" % MAXIT_HOME))
 
 
 def fromPDBToCIF(inFileName, outFileName, log):

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -303,7 +303,8 @@ Format may be PDB or MMCIF"""
                 # convert pdb to cif by using maxit program
                 log = self._log
                 localPath = localPath.replace(".pdb", ".cif")
-                fromPDBToCIF(atomStructPath, localPath, log)
+                fromPDBToCIF('"' + atomStructPath + '"',
+                             '"' + localPath + '"', log)
             elif atomStructPath.endswith(".cif"):
                 copyFile(atomStructPath, localPath)
 


### PR DESCRIPTION
(1) modify maxit installation so we may reuse the same function from another plugins. (2) add double quotes around filenames in volume import, otherwise maxit  fails if directory name has spaces