### PR TITLE
Extend Acquisition class

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -67,10 +67,14 @@ class Acquisition(EMObject):
         self._doseInitial = Float(kwargs.get('doseInitial', 0))
         self._dosePerFrame = Float(kwargs.get('dosePerFrame', None))
 
+        self.opticsGroupName = String()
+        self.beamTiltX = Float()
+        self.beamTiltY = Float()
+        self.mtfFile = String()
+        self.defectFile = String()
+
     def copyInfo(self, other):
-        self.copyAttributes(other, '_magnification', '_voltage',
-                            '_sphericalAberration', '_amplitudeContrast',
-                            '_doseInitial', '_dosePerFrame')
+        self.copy(other, copyId=False)
 
     def getMagnification(self):
         return self._magnification.get()


### PR DESCRIPTION
We are adding more general parameters to the Acquistion class. 
Right now only Relion is making use of it, but maybe other programs will do. 

copyInfo now needs to copy these new attributes as well. 