### PR TITLE
Replaced relion_volumes.mrc by relion_it015_class00*.mrc 

### DIFF
--- a/pwem/tests/protocols/test_protocols_import_volumes.py
+++ b/pwem/tests/protocols/test_protocols_import_volumes.py
@@ -184,11 +184,10 @@ class TestImportVolumes(TestImportBase):
         # position
         # """
         # Id's should be taken from filename
-        args['filesPath'] = self.dsRelion.getFile('import/case2/'
-                                                  'relion_volumes.mrc')
-        args['filesPattern'] = ''
+        args['filesPath'] = self.dsRelion.getFile('import/case2/')
+        args['filesPattern'] = 'relion_it015_class00*.mrc'
         prot2 = self.newProtocol(emprot.ProtImportVolumes, **args)
-        prot2.setObjLabel('import 3 vols from mrc stack,\n user origin,'
+        prot2.setObjLabel('import 3 mrc vols,\n user origin,'
                           '\n chimera no axis')
         self.launchProtocol(prot2)
         # Check the number of output volumes and dimensions


### PR DESCRIPTION
Dear all,
here you are a small change for running the test test_protocols_import_volumes.py in the new python3 environment: 
relion_volumes.mrc has been replaced by relion_it015_class00*.mrc as example for testing

Run the test associated:
scipion3 tests pwem.tests.protocols.test_protocols_import_volumes