### PR TITLE
Minor API additions

### DIFF
--- a/pwem/emlib/metadata/utils.py
+++ b/pwem/emlib/metadata/utils.py
@@ -48,6 +48,11 @@ class Row:
         self._labelDict = OrderedDict()  # Dictionary containing labels and values
         self._objId = None  # Set this id when reading from a metadata
 
+        # Add set and get method as alias to setValue and getValue
+        # in this way the Row will behave more like a dict
+        self.set = self.setValue
+        self.get = self.getValue
+
     def getObjId(self):
         return self._objId
 


### PR DESCRIPTION
Two changes:
* Added set/get as aliases for getValue/setValue in Row class
* Added flag doClone to copyItems. By default, it works as before, but avoiding the clone should have a good impact in performance, tested in some Relion protocols. Improved docstring for that function.