### PR TITLE
Fix import protocol

### DIFF
--- a/pwem/protocols/protocol_import/base.py
+++ b/pwem/protocols/protocol_import/base.py
@@ -76,13 +76,13 @@ class ProtImportFiles(ProtImport):
                            "The path can also contain wildcards to select"
                            "from several folders. \n\n"
                            "Examples:\n"
-                           "  ~/Particles/data/day??_micrographs/\n"
+                           "  ~/project/data/day??_files/\n"
                            "Each '?' represents one unknown character\n\n"
-                           "  ~/Particles/data/day*_micrographs/\n"
+                           "  ~/project/data/day*_files/\n"
                            "'*' represents any number of unknown characters\n\n"
-                           "  ~/Particles/data/day#_micrographs/\n"
-                           "'#' represents one digit that will be used as "
-                           "micrograph ID\n\n"
+                           "  ~/project/data/day##_files/\n"
+                           "'##' represents two digits that will be used as "
+                           "file ID\n\n"
                            "NOTE: wildcard characters ('*', '?', '#') "
                            "cannot appear in the actual path.)")
         form.addParam('filesPattern', params.StringParam,

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -57,7 +57,7 @@ class ProtImportVolumes(ProtImportImages):
         by subclasses to change what parameters to include.
         """
         form.addParam('setHalfMaps', params.BooleanParam,
-                      label='Set Half Maps',
+                      label='Set half maps',
                       help='Option YES:\nAssign two half maps to the imported map.',
                       default=False)
         form.addParam('half1map', params.PathParam,
@@ -171,6 +171,8 @@ class ProtImportVolumes(ProtImportImages):
                     newFileName2 = abspath(self._getVolumeFileName(self.half2map.get(), "mrc"))
                     emconv.Ccp4Header.fixFile(fileName, newFileName2, origin.getShifts(),
                                               samplingRate, emconv.Ccp4Header.ORIGIN)
+
+                    vol.setHalfMaps([relpath(newFileName1), relpath(newFileName2)])
             else:
                 newFileName = abspath(self._getVolumeFileName(fileName))
 
@@ -183,6 +185,11 @@ class ProtImportVolumes(ProtImportImages):
                                           abspath(self._getVolumeFileName(self.half1map.get())))
                     pwutils.createAbsLink(self.half2map.get(),
                                           abspath(self._getVolumeFileName(self.half2map.get())))
+
+
+                    vol.setHalfMaps([relpath(self._getVolumeFileName(self.half1map.get())),
+                                     relpath(self._getVolumeFileName(self.half2map.get()))
+                                     ])
 
             # Make newFileName relative
             # https://github.com/I2PC/scipion/issues/1935
@@ -197,10 +204,6 @@ class ProtImportVolumes(ProtImportImages):
                     vol.setLocation(index, newFileName)
                     volSet.append(vol)
 
-        if self.setHalfMaps.get():
-            vol.setHalfMaps([relpath(self._getVolumeFileName(self.half1map.get())),
-                             relpath(self._getVolumeFileName(self.half2map.get()))
-                             ])
         if volSet.getSize() > 1:
             self._defineOutputs(outputVolumes=volSet)
         else:
@@ -243,6 +246,20 @@ class ProtImportVolumes(ProtImportImages):
 
     def _getOrigCoord(self):
         return -1. * self.x.get(), -1. * self.y.get(), -1. * self.z.get()
+
+    def _validate(self):
+        errors = super(ProtImportVolumes, self)._validate()
+        if (not self.filesPattern.empty()) and self.setHalfMaps.get():
+            errors.append("You can not use the options 'Pattern' "
+                          "and 'Set half maps' simultaneously")
+        # Check that files are proper EM volumes, only when importing from
+        # files and not using streaming. In the later case we could
+        # have partial files not completed.
+        if (self.importFrom == self.IMPORT_FROM_FILES and
+                not self.dataStreaming):
+            errors += self._validateImages()
+
+        return errors
 
 
 class ProtImportPdb(ProtImportFiles):

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -252,12 +252,6 @@ class ProtImportVolumes(ProtImportImages):
         if (not self.filesPattern.empty()) and self.setHalfMaps.get():
             errors.append("You can not use the options 'Pattern' "
                           "and 'Set half maps' simultaneously")
-        # Check that files are proper EM volumes, only when importing from
-        # files and not using streaming. In the later case we could
-        # have partial files not completed.
-        if (self.importFrom == self.IMPORT_FROM_FILES and
-                not self.dataStreaming):
-            errors += self._validateImages()
 
         return errors
 


### PR DESCRIPTION
1) If import volume produces  a new set of half maps then the name of the new  half maps was not stored in the volume object. This bug has been fixed

2) add another check to validate. If pattern is provided then the option half maps cannot be used

The corresponding test has been created

scipion3 tests pwem.tests.protocols.test_protocols_import_volumes

