### PR TITLE
Export to DataBases

### DIFF
--- a/pwem/protocols/protocol_export/protocol_export_DB.py
+++ b/pwem/protocols/protocol_export/protocol_export_DB.py
@@ -140,7 +140,6 @@ class ProtExportDataBases(EMProtocol):
         shifts = inVol.getOrigin(force=True).getShifts()
         sampling = inVol.getSamplingRate()
 
-        print ("inVolFileName", inVolFileName)
         ccp4header = Ccp4Header(inVolFileName)
         ccp4header.fixFile(inVolFileName, outVolFileName, shifts,
                            sampling=sampling)

--- a/pwem/tests/protocols/test_protocol_export2DB.py
+++ b/pwem/tests/protocols/test_protocol_export2DB.py
@@ -136,8 +136,7 @@ class TestExport2DataBases(pwtest.BaseTest):
 
         # run Chimera rigid fit ti get a PDB file
         extraCommands = ""
-        extraCommands += "runCommand('scipionwrite model #2 refmodel #1 " \
-                         "saverefmodel 0')\n"
+        extraCommands += "runCommand('scipionwrite model #2 refmodel #1 prefix DONOTSAVESESSION_')\n"
         extraCommands += "runCommand('stop')\n"
 
         args = {'extraCommands': extraCommands,
@@ -153,7 +152,7 @@ class TestExport2DataBases(pwtest.BaseTest):
         protChimera.setObjLabel('chimera fit\n volume and PDB\n save model')
         self.launchProtocol(protChimera)
 
-        protExp.exportAtomStruct.set(protChimera.outputPdb_01)
+        protExp.exportAtomStruct.set(protChimera.DONOTSAVESESSION_Atom_struct__2)
 
         protExp.filesPath.set(os.getcwd() + "/dir2")
         self.launchProtocol(protExp)

--- a/pwem/viewers/viewer_chimera.py
+++ b/pwem/viewers/viewer_chimera.py
@@ -49,8 +49,8 @@ from pwem import getCmdPath, Config as emConfig
 
 from .showj import (CHIMERA_PORT, MODE, MODE_MD, INVERTY)
 
-chimeraPdbTemplateFileName = "chimeraOut%04d.pdb"
-chimeraMapTemplateFileName = "chimeraOut%04d.mrc"
+chimeraPdbTemplateFileName = "Atom_struct__%s.pdb"
+chimeraMapTemplateFileName = "Map__%s.mrc"
 chimeraScriptFileName = "chimeraScript.py"
 sessionFile = "SESSION.py"
 


### PR DESCRIPTION
Dear all,
we have modified the protocol export2DB to save sampling and origin in the header of each map or mask that the user would like to export.

Test:
scipion3 tests pwem.tests.protocols.test_protocol_export2DB.TestExport2DataBases