### PR TITLE
Mm emconv ccp4 header

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -433,7 +433,7 @@ def fetch_emdb_map(id, directory, tmpDirectory):
 
     originAPI = array(originAPI) * samplingAPI  # convert to Angstrom
     #check consistency between file header and rest API
-    ccp4header = Ccp4Header(map_path, readHeader=True)
+    ccp4header = emconv.Ccp4Header(map_path, readHeader=True)
     samplingHeader = ccp4header.computeSampling()  # unit = A/px
     originHeader = array(ccp4header.getOrigin())   # unit = A
 


### PR DESCRIPTION
Hi all,

here you are a tiny pull request to solve one import volumes from EMDB failing test since it did not generate the appropriate output. We have replaced the original Ccp4Header by emconv.Ccp4Header.

Test: 

scipion3 tests pwem.tests.protocols.test_protocols_import_volumes.TestImportVolumes