### PR TITLE
Read header as .mrc

### DIFF
--- a/pwem/convert/headers.py
+++ b/pwem/convert/headers.py
@@ -351,7 +351,7 @@ class Ccp4Header:
 def getFileFormat(fileName):
 
     ext = getExt(fileName)
-    if ext in ['.mrc', '.map', '.mrcs', '.mrc:mrc', '.mrc:mrcs']:
+    if ext in ['.mrc', '.map', '.mrcs', '.mrc:mrc', '.mrc:mrcs', '.st', '.rec']:
         return MRC
     elif ext == '.spi' or ext == '.vol':
         return SPIDER

--- a/pwem/emlib/image/image_handler.py
+++ b/pwem/emlib/image/image_handler.py
@@ -254,6 +254,10 @@ class ImageHandler(object):
                     doRaise=True)
                 return getImageDimensions(fn)  # we are ignoring index here
             else:
+                if ext == '.rec' or ext == '.st':
+                    location = list(location)
+                    location[1] += ":.mrc"
+                    location = tuple(location)
                 self._img.read(location, lib.HEADER)
                 return self._img.getDimensions()
         else:

--- a/pwem/emlib/image/image_handler.py
+++ b/pwem/emlib/image/image_handler.py
@@ -254,10 +254,6 @@ class ImageHandler(object):
                     doRaise=True)
                 return getImageDimensions(fn)  # we are ignoring index here
             else:
-                if ext == '.rec' or ext == '.st':
-                    location = list(location)
-                    location[1] += ":.mrc"
-                    location = tuple(location)
                 self._img.read(location, lib.HEADER)
                 return self._img.getDimensions()
         else:


### PR DESCRIPTION
This PR includes:

- Changes in headers.py to read .st and .rec (usually IMOD extensions) as .mrc natively in Scipion (without Xmipp)