### PR TITLE
Jj fix radius wizard

### DIFF
--- a/pwem/wizards/wizard.py
+++ b/pwem/wizards/wizard.py
@@ -867,14 +867,8 @@ class MaskPreviewDialog(ImagePreviewDialog):
         self.unit = getattr(self, 'unit', emcts.UNIT_PIXEL)
         self.samplingRate = self.firstItem.getSamplingRate()
         first_item_dim = self.firstItem.getDim()[0]
-
-        if self.unit == emcts.UNIT_PIXEL:
-            self.dim_par = first_item_dim
-        else:
-            self.dim_par = first_item_dim * self.samplingRate
-
+        self.dim_par = first_item_dim
         self.ratio = self.dim / float(self.dim_par)
-
         self.previewLabel = 'Central slice'
 
     def _createPreview(self, frame):


### PR DESCRIPTION
Fixes #106:
Wizard box size problema solved. Mask radius values in pixels are now coherent with the box size.
![image](https://user-images.githubusercontent.com/54907551/87763555-44a8c100-c815-11ea-9e9a-6b00a30a4e31.png)
