### PR TITLE
Metadataeditor

### DIFF
--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -38,7 +38,7 @@ import pyworkflow.plugin
 from .constants import *
 from .objects import EMObject
 from .utils import *
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -38,7 +38,7 @@ import pyworkflow.plugin
 from .constants import *
 from .objects import EMObject
 from .utils import *
-__version__ = '3.0.1b3'
+__version__ = '3.0.1'
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/pwem/protocols/__init__.py
+++ b/pwem/protocols/__init__.py
@@ -55,4 +55,5 @@ from .protocol_export import *
 from .protocol_tests import *
 
 from .protocol_origin_sampling_volume import ProtOrigSampling
+from .protocol_metadata_editor import ProtMetadataEditor
 

--- a/pwem/protocols/protocol_metadata_editor.py
+++ b/pwem/protocols/protocol_metadata_editor.py
@@ -50,7 +50,8 @@ class ProtMetadataEditor(EMProtocol):
                       help='Set which items will be modified.')
         form.addParam('formula', params.StringParam, label="Formula", important = True,
                       help='A python code compatible with eval, where item represents each of '
-                           'the elements of the set. E.g.: item._resolution.set(item._resolution.get() +1)')
+                           'the elements of the set. E.g.: item._resolution.set(item._resolution.get() +1).'
+                           'You could also use modules like "import numpy;  item._resolution .... "')
 
     def _insertAllSteps(self):
         self._insertFunctionStep('editItemsStep')

--- a/pwem/protocols/protocol_metadata_editor.py
+++ b/pwem/protocols/protocol_metadata_editor.py
@@ -1,0 +1,74 @@
+# **************************************************************************
+# *
+# * Authors:     Pablo Conesa(pconesa@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.protocol.params as params
+import pyworkflow.utils as pwutils
+from pwem.protocols import EMProtocol
+
+
+class ProtMetadataEditor(EMProtocol):
+    """
+    Protocol to edit attributes of all the items of a set using a formula.
+    This could be useful for corrupting your data for testing purposes or
+    editing some values in the set that make sense to do it. Use this with
+    extreme care, you can easily ruin your processing.
+    """
+    _label = 'metadata editor'
+
+    def _defineParams(self, form):
+        """
+        Defines the parameters the protocol form will show and its behaviour
+        :param form:
+        """
+
+        form.addSection(label='Input')
+        form.addParam('inputSet', params.PointerParam, pointerClass='EMSet',
+                      label='Set to edit',
+                      help='Set which items will be modified.')
+        form.addParam('formula', params.StringParam, label="Formula", important = True,
+                      help='A python  code compatible with eval, where item represents each of '
+                           'the elements of the set. E.g.: item._resolution.set(item._resolution.get() +1)')
+
+    def _insertAllSteps(self):
+        self._insertFunctionStep('editItemsStep')
+
+    def editItemsStep(self):
+        """
+        Goes through all items in the input set and applies the formula to each of them.
+        """
+        inputSet = self.inputSet.get()
+
+        modifiedSet = inputSet.create(self._getExtraPath())
+        modifiedSet.copyInfo(modifiedSet)
+
+        for item in inputSet.iterItems():
+            eval(self.formula.get())
+            modifiedSet.append(item)
+
+        outputArgs = {self.inputSet.getExtended(): modifiedSet}
+        self._defineOutputs(**outputArgs)
+
+

--- a/pwem/protocols/protocol_metadata_editor.py
+++ b/pwem/protocols/protocol_metadata_editor.py
@@ -57,7 +57,9 @@ class ProtMetadataEditor(EMProtocol):
 
     def editItemsStep(self):
         """
-        Goes through all items in the input set and applies the formula to each of them.
+        Goes through all items in the input set and applies the formula to each of them using exec.
+        Complex python code could be run separating lines with ;  To use numpy you could do
+        import numpy; item._resolution.set(numpy.random.randint(10))
         """
         inputSet = self.inputSet.get()
 
@@ -66,7 +68,7 @@ class ProtMetadataEditor(EMProtocol):
 
         for sourceItem in inputSet.iterItems():
             item = sourceItem.clone()
-            eval(self.formula.get())
+            exec(self.formula.get())
             modifiedSet.append(item)
 
         outputArgs = {self.inputSet.getExtended(): modifiedSet}

--- a/pwem/protocols/protocol_metadata_editor.py
+++ b/pwem/protocols/protocol_metadata_editor.py
@@ -49,7 +49,7 @@ class ProtMetadataEditor(EMProtocol):
                       label='Set to edit',
                       help='Set which items will be modified.')
         form.addParam('formula', params.StringParam, label="Formula", important = True,
-                      help='A python  code compatible with eval, where item represents each of '
+                      help='A python code compatible with eval, where item represents each of '
                            'the elements of the set. E.g.: item._resolution.set(item._resolution.get() +1)')
 
     def _insertAllSteps(self):
@@ -62,9 +62,10 @@ class ProtMetadataEditor(EMProtocol):
         inputSet = self.inputSet.get()
 
         modifiedSet = inputSet.create(self._getExtraPath())
-        modifiedSet.copyInfo(modifiedSet)
+        modifiedSet.copyInfo(inputSet)
 
-        for item in inputSet.iterItems():
+        for sourceItem in inputSet.iterItems():
+            item = sourceItem.clone()
             eval(self.formula.get())
             modifiedSet.append(item)
 

--- a/pwem/viewers/views.py
+++ b/pwem/viewers/views.py
@@ -24,7 +24,7 @@
 import csv
 import os
 import re
-
+from pyworkflow.config import Config as pwConfig
 from pyworkflow.gui import getDefaultFont, openTextFileEditor
 
 import tkinter as tk
@@ -86,8 +86,12 @@ class DataView(pwviewer.View):
     def getShowJParams(self):
         tableName = '%s@' % self._tableName if self._tableName else ''
         params = '-i "%s%s"' % (tableName, self._path)
+
         for key, value in self._viewParams.items():
             params = "%s --%s %s" % (params, key, value)
+
+        if pwConfig.debugOn():
+            params += " --debug"
 
         return params
 


### PR DESCRIPTION
This protocol is to generically edit an item in a set. 

We've had 2 cases already for this:

1.- set "amplitude contrast" to a different value of the one specified at import time. It seems (the case is reasonable under certain circumstances)

2.- Set random values to some metadata attributes. This escapes any standard image processing, but was needed to make test and evaluate image processing protocols when data is wrong.

It also passes Scipion DEBUG mode to ShowJ.
