### PR TITLE
Rm atom struct

### DIFF
--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -689,13 +689,13 @@ class AtomicStructHandler:
         io.set_structure(self.structure)
         io.save(filename, sel)
 
-    def reNameChain(self, chainID, newChainName, modelID='0',
+    def renameChain(self, chainID, newChainName, modelID='0',
                     filename="output.mmcif"):
         self.structure[modelID][chainID].id = newChainName
         self.write(filename)
 
 
-    def reNumberChain(self, chainID, offset=0, modelID='0',
+    def renumberChain(self, chainID, offset=0, modelID='0',
                     filename="output.mmcif"):
         # get chain object
         chain = self.structure[modelID][chainID]

--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -689,6 +689,34 @@ class AtomicStructHandler:
         io.set_structure(self.structure)
         io.save(filename, sel)
 
+    def reNameChain(self, chainID, newChainName, modelID='0',
+                    filename="output.mmcif"):
+        self.structure[modelID][chainID].id = newChainName
+        self.write(filename)
+
+
+    def reNumberChain(self, chainID, offset=0, modelID='0',
+                    filename="output.mmcif"):
+        # get chain object
+        chain = self.structure[modelID][chainID]
+        # remove chain from model
+        self.structure[modelID].detach_child(chainID)
+        from Bio.PDB.Chain import Chain
+        # create new chain
+        newChain = Chain(chainID)
+        for residue in chain:
+            # remove residue, otherwise we cannot renumber it
+            residue.detach_parent()
+            rId = residue.id
+            res_id = list(rId)
+            res_id[1] = res_id[1] + offset
+            if res_id[1] <0 :
+                raise ValueError('Residue number cant be <= 0')
+            residue.id = tuple(res_id)
+            newChain.add(residue)
+        self.structure[modelID].add(newChain)
+        self.write(filename)
+
 
 def cifToPdb(fnCif, fnPdb):
     h = AtomicStructHandler()

--- a/pwem/protocols/protocol_alignment_invertHand.py
+++ b/pwem/protocols/protocol_alignment_invertHand.py
@@ -61,7 +61,7 @@ class ProtAlignmentInvertHand(ProtAlign2D):
         step = total // width
 
         # print a progressba since this make take for ever
-        pb = ProgressBar(total=total, width=width)
+        pb = ProgressBar(total=total, width=width,fmt=ProgressBar.NOBAR)
         from time import sleep
         for counter, particle in enumerate(inputParticles):
             sleep(0.01)

--- a/pwem/protocols/protocol_alignment_invertHand.py
+++ b/pwem/protocols/protocol_alignment_invertHand.py
@@ -61,7 +61,7 @@ class ProtAlignmentInvertHand(ProtAlign2D):
         step = total // width
 
         # print a progressba since this make take for ever
-        pb = ProgressBar(total=total, width=width,fmt=ProgressBar.NOBAR)
+        pb = ProgressBar(total=total, width=width, fmt=ProgressBar.NOBAR)
         from time import sleep
         for counter, particle in enumerate(inputParticles):
             sleep(0.01)


### PR DESCRIPTION
add renumber and rename functions to atom_struct.py which allows to shift the residues  position by an offset and change the chain name


Also a have modified the format used by invert_hand protocol to print the progressbar 
since scipion uses variable fonts so the bar size changes in each print
because   the "space" width is different from the "=" width
