### PR TITLE
Fix assign angles shifts before

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1577,28 +1577,12 @@ class Transform(EMObject):
         m *= factor
         m[3, 3] = 1.
 
-    def scaleShifts(self, factor, shiftsAppliedBefore=False, invert=False):
-
+    def scaleShifts(self, factor):
         # By default Scipion uses a coordinate system associated with the volume rather than the projection
         m = self.getMatrix()
-
-        # If shifts applied in the "projection", the matrix needs to be
-        # expressed in the system of coordinates associated to the projection
-        if shiftsAppliedBefore:
-            if invert:
-                m = self.invert()
-
-            m[0, 3] -= int(m[0,3])  # Decimal part of X translation
-            m[1, 3] -= int(m[1,3])  # Decimal part of Y translation
-
         m[0, 3] *= factor
         m[1, 3] *= factor
         m[2, 3] *= factor
-
-        # Revert the inversion done before to have it
-        # related to the coordinate system associated to the volume and not the projection
-        if invert:
-           self.invert()
 
     def invert(self):
         # Local import to avoid loop pwem --> data --> convert --> Plugin (at pwem)

--- a/pwem/protocols/protocol_alignment_assign.py
+++ b/pwem/protocols/protocol_alignment_assign.py
@@ -80,11 +80,23 @@ class ProtAlignmentAssign(ProtAlign2D):
         alignedParticle = inputAlignment[item.getObjId()]
         # If alignment is found for this particle set the alignment info
         # on the output particle, if not do not write that item
-        if alignedParticle is not None:
+        if item.hasCoordinate() and hasattr(item.getCoordinate(), "xFrac"):
+
+            coord = item.getCoordinate()
+
             alignment = alignedParticle.getTransform()
-            alignment.scaleShifts(
-                scale, shiftsAppliedBefore=self.shiftsAppliedBefore.get(), invert=True)
+            alignment.invert()
+            alignment.setShifts(-coord.xFrac.get(),
+                               -coord.yFrac.get(),
+                               0)
+            alignment.invert()
             item.setTransform(alignment)
+
+        # if alignedParticle is not None:
+        #     alignment = alignedParticle.getTransform()
+        #     alignment.scaleShifts(
+        #         scale, shiftsAppliedBefore=self.shiftsAppliedBefore.get(), invert=True)
+        #     item.setTransform(alignment)
 
             if self.assignRandomSubsets:
                 subset = \

--- a/pwem/protocols/protocol_alignment_assign.py
+++ b/pwem/protocols/protocol_alignment_assign.py
@@ -163,12 +163,3 @@ class ProtAlignmentAssign(ProtAlign2D):
             
         # Add some errors if input is not valid
         return errors
-
-    def _warnings(self):
-        validateMsgs = []
-        if self.shiftsAppliedBefore.get():
-            validateMsgs.append("This option should be set to Yes only if the particle shifts have been applied "
-                                "before.\nIf selected, only the remaining decimal part of the shifts will be applied " +
-                                " for 'x' and 'y'  in the translation component of the transformation matrix. This " +
-                                "will carry longer execution times. Please read the help for further information.")
-        return validateMsgs

--- a/pwem/protocols/protocol_alignment_assign.py
+++ b/pwem/protocols/protocol_alignment_assign.py
@@ -86,8 +86,8 @@ class ProtAlignmentAssign(ProtAlign2D):
 
             alignment = alignedParticle.getTransform()
             alignment.invert()
-            alignment.setShifts(-coord.xFrac.get(),
-                               -coord.yFrac.get(),
+            alignment.setShifts(coord.xFrac.get(),
+                               coord.yFrac.get(),
                                0)
             alignment.invert()
             item.setTransform(alignment)

--- a/pwem/protocols/protocol_alignment_assign.py
+++ b/pwem/protocols/protocol_alignment_assign.py
@@ -48,10 +48,6 @@ class ProtAlignmentAssign(ProtAlign2D):
         form.addParam('inputAlignment', params.PointerParam, pointerClass='SetOfParticles',
                       label="Input alignments",
                       help='Select the particles with alignment to be apply to the other particles.')
-        form.addParam('shiftsAppliedBefore', params.BooleanParam, default=False,
-                      label='Were particle shifts applied?',
-                      help='Activate this option only if the advanced option "Apply particle shifts" was set to Yes '
-                           'at the extract coordinates protocol.')
         form.addParam('assignRandomSubsets', params.BooleanParam, default=True,
                       expertLevel=params.LEVEL_ADVANCED,
                       label="Assign random subsets?",
@@ -80,23 +76,24 @@ class ProtAlignmentAssign(ProtAlign2D):
         alignedParticle = inputAlignment[item.getObjId()]
         # If alignment is found for this particle set the alignment info
         # on the output particle, if not do not write that item
-        if item.hasCoordinate() and hasattr(item.getCoordinate(), "xFrac"):
-
-            coord = item.getCoordinate()
-
+        if alignedParticle is not None:
             alignment = alignedParticle.getTransform()
-            alignment.invert()
-            alignment.setShifts(coord.xFrac.get(),
-                               coord.yFrac.get(),
-                               0)
-            alignment.invert()
-            item.setTransform(alignment)
 
-        # if alignedParticle is not None:
-        #     alignment = alignedParticle.getTransform()
-        #     alignment.scaleShifts(
-        #         scale, shiftsAppliedBefore=self.shiftsAppliedBefore.get(), invert=True)
-        #     item.setTransform(alignment)
+            # If shifts Applied before at extraction coordinate time
+            if item.hasCoordinate() and hasattr(item.getCoordinate(), "xFrac"):
+                coord = item.getCoordinate()
+
+                alignedParticle = inputAlignment[item.getObjId()]
+
+                alignment.invert()
+                alignment.setShifts(-coord.xFrac.get(),
+                                -coord.yFrac.get(),
+                                0)
+                alignment.invert()
+            else:
+                alignment.scaleShifts(scale)
+
+            item.setTransform(alignment)
 
             if self.assignRandomSubsets:
                 subset = \

--- a/pwem/protocols/protocol_alignment_assign.py
+++ b/pwem/protocols/protocol_alignment_assign.py
@@ -83,7 +83,7 @@ class ProtAlignmentAssign(ProtAlign2D):
         if alignedParticle is not None:
             alignment = alignedParticle.getTransform()
             alignment.scaleShifts(
-                scale, shiftsAppliedBefore=self.shiftsAppliedBefore.get())
+                scale, shiftsAppliedBefore=self.shiftsAppliedBefore.get(), invert=True)
             item.setTransform(alignment)
 
             if self.assignRandomSubsets:

--- a/pwem/protocols/protocol_extract_coordinates.py
+++ b/pwem/protocols/protocol_extract_coordinates.py
@@ -194,8 +194,8 @@ class ProtExtractCoords(ProtParticlePickingAuto):
                     shifts = self.getShifts(part.getTransform(), alignType)
 
                     # Add the shifts (values are inverted so subtract)
-                    x += shifts[0]
-                    y += shifts[1]
+                    x -= shifts[0]
+                    y -= shifts[1]
 
                 # Apply the scale
                 x *= scale

--- a/pwem/protocols/protocol_extract_coordinates.py
+++ b/pwem/protocols/protocol_extract_coordinates.py
@@ -204,8 +204,11 @@ class ProtExtractCoords(ProtParticlePickingAuto):
                 # Round coordinates to closer integer 39.9 --> 40 and not 39
                 finalX = round(x)
                 finalY = round(y)
-                newCoord.xFrac = Float(finalX - x)
-                newCoord.yFrac = Float(finalY-y)
+
+                # Annotate fractions if shifts applied
+                if self.applyShifts:
+                    newCoord.xFrac = Float(finalX - x)
+                    newCoord.yFrac = Float(finalY-y)
                 newCoord.setPosition(finalX, finalY)
 
                 newCoord.setMicrograph(mic)


### PR DESCRIPTION
This fixes 2 issues:
1.- shift in Z of projection alignment are 0 (before some value was written due to Transfor.scaleShifts working on the non inverted matrix

2.- When combining extract coordinates with assign angles final shift should be more accurate.

I'd like to discuss this with @delarosatrevin. This PR implies setting xFrac and yFrac in the Coordinate object for future alignment assign. They can be removed at alignment assign time and we can avoid asking since new attributes can be detected.