### PR TITLE
do not use tmp path for chimera viewer

### DIFF
--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -39,7 +39,7 @@ from .constants import *
 from .objects import EMObject
 from .utils import *
 
-__version__ = '3.0.6'
+__version__ = '3.0.7'
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/pwem/viewers/viewer_volumes.py
+++ b/pwem/viewers/viewer_volumes.py
@@ -104,7 +104,7 @@ class viewerProtImportVolumes(EmProtocolViewer):
 
     def _showVolumesChimera(self):
         """ Create a chimera script to visualize selected volumes. """
-        tmpFileNameCMD = self.protocol._getTmpPath("chimera.cxc")
+        tmpFileNameCMD = self.protocol._getExtraPath("chimera.cxc")
         f = open(tmpFileNameCMD, "w")
         sampling, _setOfVolumes = self._createSetOfVolumes()
         count = 1  # chimeraX stars counting in 1 (chimera in 0)
@@ -116,7 +116,7 @@ class viewerProtImportVolumes(EmProtocolViewer):
             # be in the center of the window
 
             dim = self.protocol.outputVolume.getDim()[0]
-            tmpFileNameBILD = os.path.abspath(self.protocol._getTmpPath(
+            tmpFileNameBILD = os.path.abspath(self.protocol._getExtraPath(
                 "axis.bild"))
             Chimera.createCoordinateAxisFile(dim,
                                              bildFileName=tmpFileNameBILD,


### PR DESCRIPTION
This fixes the viewer since from the last update the tmp folder does not remain after protocol execution.

So viewer should not assume tmp exists anymore. We use extra now, Another option would be to use system /tmp if it is actually temporary.