### PR TITLE
1 mm scipion3 sampling inspect chain

### DIFF
--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -257,9 +257,6 @@ class AtomicStructHandler:
         self._readDone = True
 
     def checkRead(self):
-        import inspect
-
-        print('caller name checkRead:', inspect.stack()[1][3])
         if self._readDone:
             return True
         else:
@@ -324,9 +321,6 @@ class AtomicStructHandler:
         return listOfChains, listOfResidues
 
     def getSequenceFromChain(self, modelID, chainID):
-        import inspect
-
-        print('caller name getSequenceFromChain:', inspect.stack()[1][3])
         self.checkRead()
         seq = list()
         for model in self.structure:

--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -257,6 +257,9 @@ class AtomicStructHandler:
         self._readDone = True
 
     def checkRead(self):
+        import inspect
+
+        print('caller name checkRead:', inspect.stack()[1][3])
         if self._readDone:
             return True
         else:
@@ -321,6 +324,9 @@ class AtomicStructHandler:
         return listOfChains, listOfResidues
 
     def getSequenceFromChain(self, modelID, chainID):
+        import inspect
+
+        print('caller name getSequenceFromChain:', inspect.stack()[1][3])
         self.checkRead()
         seq = list()
         for model in self.structure:

--- a/pwem/protocols/protocol_import/sequence.py
+++ b/pwem/protocols/protocol_import/sequence.py
@@ -320,12 +320,10 @@ class ProtImportSequence(ProtImportFiles):
             # PDB from remote database
             pdbID = self.pdbId.get()
             tmpFilePath = os.path.join("/tmp", pdbID + ".cif").lower()
-            if exists(tmpFilePath):
-                # wizard already downloaded the file
-                self.structureHandler.read(tmpFilePath)
-            else:
+            if not exists(tmpFilePath):
                 # wizard has not used and the file has not been downloaded yet
                 self.structureHandler.readFromPDBDatabase(pdbID, dir="/tmp")
+            self.structureHandler.read(tmpFilePath)
         else:
             # PDB from file
             self.structureHandler.read(self.pdbFile.get())

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -40,6 +40,7 @@ from pwem import emlib
 from .base import ProtImportFiles
 from .images import ProtImportImages
 from ...convert import Ccp4Header
+from pyworkflow.object import Float
 
 
 class ProtImportVolumes(ProtImportImages):
@@ -232,6 +233,8 @@ class ProtImportVolumes(ProtImportImages):
                 print(e)
                 return
             # open volume and fill sampling and origin
+            self.samplingRate.set(sampling)
+            self._store(self.samplingRate)
             vol.setSamplingRate(sampling)
             vol.setFileName(localFileName)
             from pwem.objects.data import Transform

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -39,8 +39,6 @@ from pwem import emlib
 
 from .base import ProtImportFiles
 from .images import ProtImportImages
-from ...convert import Ccp4Header
-from pyworkflow.object import Float
 
 
 class ProtImportVolumes(ProtImportImages):

--- a/pwem/protocols/protocol_origin_sampling_volume.py
+++ b/pwem/protocols/protocol_origin_sampling_volume.py
@@ -129,8 +129,6 @@ class ProtOrigSampling(EMProtocol):
         # Files system stuff
         fileName = os.path.abspath(self.inVol.getFileName())
         fileName = fileName.replace(':mrc', '')
-        # imgBase = pwutils.replaceBaseExt(fileName, "mrc")
-        # imgDst = self._getExtraPath(imgBase)
 
         # copy or link
         if self.copyFiles:

--- a/pwem/protocols/protocol_origin_sampling_volume.py
+++ b/pwem/protocols/protocol_origin_sampling_volume.py
@@ -88,13 +88,13 @@ class ProtOrigSampling(EMProtocol):
                                  "Å (pixels x sampling).\n",
                                  condition='setOrigCoord')
         line.addParam('x', params.FloatParam,
-                      label="x",
+                      label="x", default=0.,
                       help="offset along x axis (Å)")
         line.addParam('y', params.FloatParam,
-                      label="  y",
+                      label="  y", default=0.,
                       help="offset along y axis (Å)")
         line.addParam('z', params.FloatParam,
-                      label="  z",
+                      label="  z", default=0.,
                       help="offset along z axis (Å)")
 
     # --------------------------- INSERT steps functions ----------------------
@@ -129,14 +129,18 @@ class ProtOrigSampling(EMProtocol):
         # Files system stuff
         fileName = os.path.abspath(self.inVol.getFileName())
         fileName = fileName.replace(':mrc', '')
-        imgBase = pwutils.replaceBaseExt(fileName, "mrc")
-        imgDst = self._getExtraPath(imgBase)
+        # imgBase = pwutils.replaceBaseExt(fileName, "mrc")
+        # imgDst = self._getExtraPath(imgBase)
 
         # copy or link
         if self.copyFiles:
+            imgBase = pwutils.replaceBaseExt(fileName, "mrc")
+            imgDst = self._getExtraPath(imgBase)
             Ccp4Header.fixFile(fileName,imgDst, origin.getShifts(),
                                sampling=samplingRate)
         else:
+            imgBase = basename(fileName)
+            imgDst = self._getExtraPath(imgBase)
             pwutils.createAbsLink(fileName, imgDst)
 
         self.outVol.setLocation(imgDst)

--- a/pwem/viewers/viewer_sequence.py
+++ b/pwem/viewers/viewer_sequence.py
@@ -63,10 +63,10 @@ class SequenceViewer(pwviewer.Viewer):
         seqName = obj.getSeqName()
         seqDescription = obj.getDescription()
         seqFileName = os.path.abspath(
-            self.protocol._getTmpPath(seqName + ".fasta"))
-        # Step 3: Sequence saved in the tmp file
+            self.protocol._getExtraPath(seqName + ".fasta"))
+        # Step 3: Sequence saved in the extra file
         seqHandler.saveFile(seqFileName, seqID, sequence=seqBio,
                             name=seqName, seqDescription=seqDescription,
                             type="fasta")
-        # Step 4: Visualization of tmp file
+        # Step 4: Visualization of extra file
         openTextFileEditor(seqFileName)


### PR DESCRIPTION
Hi all,

some small changes are included in this pull request to fix some general small errors, among them:

* Visualization of sequences (USER_SEQ.txt file saved now in extra folder).
* Downloading of an atomic structure before opening its sequence (case 3rrq in TestChimeraModellerSearch, which failed previously)
* Added default values of x, y, z origin coordinates and not assigned the 'mrc' extension when the input map is not copied,

Tests:

scipion3 tests pwem.tests.protocols.test_protocols_import_sequence.TestImportSequence
scipion3 tests chimera.tests.test_protocol_modeller_search.TestChimeraModellerSearch
scipion3 tests pwem.tests.protocols.test_protocols_assign_orig.TestOriginSampling