### PR TITLE
use abs path for tmp symlinks

### DIFF
--- a/pwem/protocols/protocol_movies.py
+++ b/pwem/protocols/protocol_movies.py
@@ -299,7 +299,7 @@ class ProtProcessMovies(ProtPreprocessMicrographs):
 
         if self._filterMovie(movie):
             pwutils.makePath(movieFolder)
-            pwutils.createLink(movieFn, join(movieFolder, movieName))
+            pwutils.createAbsLink(os.path.abspath(movieFn), join(movieFolder, movieName))
 
             if movieName.endswith('bz2'):
                 newMovieName = movieName.replace('.bz2', '')


### PR DESCRIPTION
In case when SCIPION_SCRATCH is set, abs links are required for files inside tmp folder