### PR TITLE
Create a subset in a generic way when inputObj is a protocol and set …

### DIFF
--- a/pwem/protocols/protocol_batch.py
+++ b/pwem/protocols/protocol_batch.py
@@ -124,6 +124,13 @@ class ProtUserSubSet(BatchProtocol):
                     volSet.loadAllProperties()
                     self._createSimpleSubset(volSet)
 
+                # Go for a generic way of creating the set the the
+                # input set is not registered (typically from viewers)
+                else:
+                    # We might want to do this before, inside the createSetObject
+                    setObj.loadAllProperties()
+                    self._createSimpleSubset(setObj)
+
         else:
             self._createSimpleSubset(inputObj)
 
@@ -461,7 +468,6 @@ class ProtUserSubSet(BatchProtocol):
         # Ignoring self._dbPrefix here, since we want to load
         # the top-level set in the sqlite file
         setObj = loadSetFromDb(self._dbName)
-
         return setObj
 
     def _summary(self):


### PR DESCRIPTION
…is not registered in scipion.

Closes https://github.com/scipion-em/scipion-em-motioncorr/issues/41