### PR TITLE
Rm transformation matrix

### DIFF
--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -36,7 +36,7 @@ from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.PDBParser import PDBParser
 from Bio.PDB import PDBIO, MMCIFIO
 from Bio.PDB.mmcifio import mmcif_order
-
+from Bio.PDB import Superimposer
 from Bio.PDB.MMCIF2Dict import MMCIF2Dict
 from Bio.PDB import Entity
 from Bio.PDB import PDBList
@@ -534,6 +534,62 @@ class AtomicStructHandler:
             Be aware that this is not a lossless conversion
         """
         self._write(cifFile)
+
+    def getTransformMatrix(self, atomStructFn, startId=-1, endId=-1):
+        """find matrix that Superimposes two atom structures.
+        this matrix moves atomStructFn to self """
+        if endId == -1:
+            endId = 10000000
+        # load second atom structure
+        aSH = AtomicStructHandler()
+        aSH.read(atomStructFn)
+
+        # Use the first model in the atom struct for alignment
+        ref_model = self.getStructure()[0]
+        sample_model = aSH.getStructure()[0]
+
+        # Make a list of the atoms (in the structures) you wish to align.
+        # In this case we use CA atoms whose index is in the
+        # specified range (starId, endId)
+        ref_atoms = []
+        sample_atoms = []
+
+        # Now get a list with CA atoms (alpha-carbon)
+        # I assume that both atom structs have the same number of chains
+        # and in the same order.
+        for ref_chain, sample_chain in zip(ref_model, sample_model):
+            # create a set with the id of all residues
+            # for the current chain
+            ref_set_id = set(res.get_id()[1] for res in ref_chain)
+            sample_set_id = set(res.get_id()[1] for res in sample_chain)
+            # keep the intersection as an ordered list (sets are not ordered)
+            ref_set_id.intersection_update(sample_set_id)
+            ref_list_id = sorted(ref_set_id)
+            # delete AA smaller or large than the predefined values
+            ref_list_id[:] = [x for x in ref_list_id
+                              if x >= startId and x <= endId]
+
+            # Iiterate through all residues in each chain a store CA atoms
+            for id in ref_list_id:
+                ref_atoms.append(ref_chain[id]['CA'])
+                sample_atoms.append(sample_chain[id]['CA'])
+        # Now we initiate the superimposer:
+        super_imposer = Superimposer()
+        super_imposer.set_atoms(ref_atoms, sample_atoms)
+        # super_imposer.apply(sample_model.get_atoms())
+        (rot, trans) = super_imposer.rotran
+        # DEBUG, uncomment next two lines to see
+        # transformation applied to atomStructFn
+        # aSH.getStructure().transform(rot, trans)
+        # aSH.write("/tmp/pp.cif")
+
+        # convert 3x3 rotation matrix to homogeneous matrix
+        rot = numpy.transpose(rot)  # scipion and biopython use
+                                    # different conventions
+        tmp = numpy.r_[rot, numpy.zeros((1, 3))]
+        mat = numpy.c_[tmp, numpy.array(
+            [[trans[0]], [trans[1]], [trans[2]], [1]])]
+        return mat, super_imposer.rms
 
     def centerOfMass(self, geometric=False):
         """

--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -535,6 +535,39 @@ class AtomicStructHandler:
         """
         self._write(cifFile)
 
+    def getBoundingBox(self, expand=3):
+        """Get bounding box (angstroms) for atom struct.
+         Only alpha carbons are taken into account.
+         parameter: expand.- make box larger addind this factor
+         """
+        # Use the first model
+        ref_model = self.getStructure()[0]
+        # init bounding box volues
+        xmin = 100000; ymin = xmin; zmin = xmin
+        xmax = -100000; ymax = xmax; zmax = xmax
+        # iterate for all aminoacids
+        for chain in ref_model:
+            for residue in chain:
+                (x,y,z) = residue["CA"].get_coord()
+                if x < xmin: xmin = x
+                if x > xmax: xmax = x
+
+                if y < ymin: ymin = y
+                if y > ymax: ymax = y
+
+                if z < zmin: zmin = z
+                if z > zmax: zmax = z
+            # DEBUG
+            # with open("/tmp/kk.bild", "w") as file:
+            #     file.write(".transparency 0.8\n"
+            #                ".color red\n"
+            #                ".box %f %f %f %f %f %f\n" %
+            #                (xmin - expand , ymin - expand, zmin - expand,
+            #                xmax + expand, ymax + expand, zmax + expand))
+        return [[xmin - expand, ymin - expand, zmin - expand],
+                [xmax + expand, ymax + expand, zmax + expand]]
+
+
     def getTransformMatrix(self, atomStructFn, startId=-1, endId=-1):
         """find matrix that Superimposes two atom structures.
         this matrix moves atomStructFn to self """

--- a/pwem/protocols/protocol_origin_sampling_volume.py
+++ b/pwem/protocols/protocol_origin_sampling_volume.py
@@ -129,14 +129,16 @@ class ProtOrigSampling(EMProtocol):
         # Files system stuff
         fileName = os.path.abspath(self.inVol.getFileName())
         fileName = fileName.replace(':mrc', '')
-        imgBase = pwutils.replaceBaseExt(fileName, "mrc")
-        imgDst = self._getExtraPath(imgBase)
 
         # copy or link
         if self.copyFiles:
+            imgBase = pwutils.replaceBaseExt(fileName, "mrc")
+            imgDst = self._getExtraPath(imgBase)
             Ccp4Header.fixFile(fileName,imgDst, origin.getShifts(),
                                sampling=samplingRate)
         else:
+            imgBase = basename(fileName)
+            imgDst = self._getExtraPath(imgBase)
             pwutils.createAbsLink(fileName, imgDst)
 
         self.outVol.setLocation(imgDst)

--- a/pwem/tests/data/test_convert_atom_struct.py
+++ b/pwem/tests/data/test_convert_atom_struct.py
@@ -966,7 +966,7 @@ HETATM 5 C CB . PRO B 1 . 1 ? 6.460 21.723 20.211 1.00 22.26 ? ? ? ? ? ? ? 1 PRO
         cls.CIFFileName = f.name
 
     def testGetTransformMatrix(self):
-        # save files with h1 and h2
+        # create and load atom struct
         from .hexonAtomStruct import saveFiles
         h1Fn, h2Fn = saveFiles()
         aSH = emconv.AtomicStructHandler(h1Fn)
@@ -993,3 +993,15 @@ HETATM 5 C CB . PRO B 1 . 1 ? 6.460 21.723 20.211 1.00 22.26 ? ? ? ? ? ? ? 1 PRO
         # aSH2.transform(matrix)
         # aSH2.write("/tmp/kk.cif")
 
+    def testGetBoundingBox(self):
+        # create and load atom struct
+        from .hexonAtomStruct import saveFiles
+        h1Fn, h2Fn = saveFiles()
+        aSH = emconv.AtomicStructHandler(h1Fn)
+        [[x1, y1, z1],[x2, y2, z2]] = aSH.getBoundingBox()
+        self.assertAlmostEqual(x1, 205.438 - 3, places=2)
+        self.assertAlmostEqual(y1, -92.590 - 3, places=2)
+        self.assertAlmostEqual(z1, 240.313 - 3, places=2)
+        self.assertAlmostEqual(x2, 328.960 + 3, places=2)
+        self.assertAlmostEqual(y2,   2.663 + 3, places=2)
+        self.assertAlmostEqual(z2, 352.586 + 3, places=2)

--- a/pwem/viewers/viewer_chimera.py
+++ b/pwem/viewers/viewer_chimera.py
@@ -208,6 +208,7 @@ class ChimeraAngDist(pwviewer.CommandView):
         fhCmd.write("volume #3 voxelSize %s\n" % self.voxelSize)
         x, y, z = self.volOrigin
         fhCmd.write("volume #3 origin %s,%s,%s\n" % (x, y, z))
+        fhCmd.write("view\n")
 
         fhCmd.close()
 
@@ -362,6 +363,7 @@ class ChimeraViewer(pwviewer.Viewer):
                 f.write("open %s\n" % bildFileName)
                 f.write("open %s\n" % os.path.abspath(fn))
                 f.write("style stick")
+                f.write("view\n")
                 f.close()
                 ChimeraView(fnCmd).show()
             # FIXME: there is an asymmetry between ProtocolViewer and Viewer
@@ -482,4 +484,5 @@ def mapVolsWithColorkey(displayVolFileName,
 
         fhCmd.write(command)
         labelCount += 1
+    fhCmd.write("run(session, 'view')\n")
     fhCmd.close()

--- a/pwem/viewers/viewer_volumes.py
+++ b/pwem/viewers/viewer_volumes.py
@@ -152,6 +152,7 @@ class viewerProtImportVolumes(EmProtocolViewer):
                             (count, x, y, z))
                     f.write("tile\n")
                     count += 1
+        f.write("view\n")
         f.close()
         return [ChimeraView(tmpFileNameCMD)]
 


### PR DESCRIPTION
Added function   getTransformMatrix and getBoundingBox which find the matrix that Superimposes two atom structures and, for a given atom structure, its bounding box.

tests:
scipion3 tests pwem.tests.data.test_convert_atom_struct.TestAtomicStructHandler.testGetTransformMatrix
scipion3 tests pwem.tests.data.test_convert_atom_struct.TestAtomicStructHandler.testGetBoundingBox

===========
I have also added the command "view" to the chimera visualization script. In this way  all loaded elements are in the view field. By default chimera uses the first loaded element to define the view field. That is if you load first a small object and then a large one you will no see the large one. View redefines the view field so all objects are visible

