### PR TITLE
Tolerate error in movie alignment method when "preprocess fails" 

### DIFF
--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -39,7 +39,7 @@ from .constants import *
 from .objects import EMObject
 from .utils import *
 
-__version__ = '3.0.8'
+__version__ = '3.0.9'
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/pwem/protocols/protocol_align_movies.py
+++ b/pwem/protocols/protocol_align_movies.py
@@ -243,7 +243,12 @@ class ProtAlignMovies(ProtProcessMovies):
                                             "can't add it to output set." % extraMicFn))
                     doneFailed.append(movie)
                     continue
-                self._preprocessOutputMicrograph(mic, movie)
+                # Tolerate errors here. Usually here some plots are generated.
+                try:
+                    self._preprocessOutputMicrograph(mic, movie)
+                except Exception as e:
+                    self.error("Couldn't prepare output details: %s" % e)
+
                 micSet.append(mic)
 
             self._updateOutputSet(outputName, micSet, streamMode)


### PR DESCRIPTION
at least we'll have the mics without plots and protocol does not fail.

Not sure if just having the mic will be an issue later. If so, other option would be to skip the mic.

This is triggered by several K3 acquisitions, that occasionally output movies with 1 less frame.

Optionally, maybe the "preprocessing" method could be modified to tolerate different frame numbers.
