### PR TITLE
take the name FirstJoinStep form the method name. Relion picking is "…

### DIFF
--- a/pwem/protocols/protocol_particles_picking.py
+++ b/pwem/protocols/protocol_particles_picking.py
@@ -526,7 +526,7 @@ class ProtParticlePickingAuto(ProtParticlePicking):
         # the first function that need to wait for all micrographs
         # to have completed, this can be overwritten in subclasses
         # (eg in Xmipp 'sortPSDStep')
-        return 'createOutputStep'
+        return self.createOutputStep.__name__
 
     def _getFirstJoinStep(self):
         for s in self._steps:


### PR DESCRIPTION
…reassigning" this method using "_doNothing" and latest changes take the function name, which in this case is "_doNothing".