### PR TITLE
Added page break to allow the opening of text .cxc file

### DIFF
--- a/pwem/viewers/viewer_chimera.py
+++ b/pwem/viewers/viewer_chimera.py
@@ -357,7 +357,7 @@ class ChimeraViewer(pwviewer.Viewer):
                                                  sampling=sampling)
                 f.write("open %s\n" % bildFileName)
                 f.write("open %s\n" % os.path.abspath(fn))
-                f.write("style stick")
+                f.write("style stick\n")
                 f.write("view\n")
                 f.close()
                 ChimeraView(fnCmd).show()


### PR DESCRIPTION
Hi all,

here you have a tiny fix since otherwise the words "stick" and "view" are only one word avoiding visualizing results in ChimeraX (an atomic structure imported in this case).