### PR TITLE
fixes in ctfStr astigmatism definition

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -140,7 +140,7 @@ class CTFModel(EMObject):
                  "psh={}, res={}, fit={}".format(
             strEx(self._defocusU.get()),
             strEx(self._defocusV.get()),
-            strEx(self._defocusU.get()-self._defocusV.get()),
+            strEx(self._defocusU.get(0)-self._defocusV.get(0)),
             strEx(self.getPhaseShift()),
             strEx(self._resolution.get()),
             strEx(self._fitQuality.get())

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -140,7 +140,7 @@ class CTFModel(EMObject):
                  "psh={}, res={}, fit={}".format(
             strEx(self._defocusU.get()),
             strEx(self._defocusV.get()),
-            strEx(self._defocusAngle.get()),
+            strEx(self._defocusRatio.get()),
             strEx(self.getPhaseShift()),
             strEx(self._resolution.get()),
             strEx(self._fitQuality.get())

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -140,7 +140,7 @@ class CTFModel(EMObject):
                  "psh={}, res={}, fit={}".format(
             strEx(self._defocusU.get()),
             strEx(self._defocusV.get()),
-            strEx(self._defocusRatio.get()),
+            strEx(self._defocusU.get()-self._defocusV.get()),
             strEx(self.getPhaseShift()),
             strEx(self._resolution.get()),
             strEx(self._fitQuality.get())


### PR DESCRIPTION
This PR includes:

- Fixes in CTFModes,  __str__ method. Astigmatism is equal to the defocus difference (no defocusAngle)