### PR TITLE
Protect defocus ratio calculation in standarize method (CTFModel)

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -122,6 +122,7 @@ class Acquisition(EMObject):
 class CTFModel(EMObject):
     """ Represents a generic CTF model. """
 
+    DEFOCUS_V_MINIMUM_VALUE = 0.1
     DEFOCUS_RATIO_ERROR_VALUE = -1
 
     def __init__(self, **kwargs):
@@ -254,7 +255,7 @@ class CTFModel(EMObject):
         # At this point defocusU is always greater than defocusV
         # following the EMX standard
 
-        if self.getDefocusV() != 0:
+        if self.getDefocusV() > self.DEFOCUS_V_MINIMUM_VALUE:
             self._defocusRatio.set(self.getDefocusU() / self.getDefocusV())
         else:
             self._defocusRatio.set(self.DEFOCUS_RATIO_ERROR_VALUE)

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -119,6 +119,8 @@ class Acquisition(EMObject):
 class CTFModel(EMObject):
     """ Represents a generic CTF model. """
 
+    DEFOCUS_RATIO_ERROR_VALUE = -1
+
     def __init__(self, **kwargs):
         EMObject.__init__(self, **kwargs)
         self._defocusU = Float(kwargs.get('defocusU', None))
@@ -248,7 +250,11 @@ class CTFModel(EMObject):
             self._defocusAngle.sum(180.)
         # At this point defocusU is always greater than defocusV
         # following the EMX standard
-        self._defocusRatio.set(self.getDefocusU() / self.getDefocusV())
+
+        if self.getDefocusV() != 0:
+            self._defocusRatio.set(self.getDefocusU() / self.getDefocusV())
+        else:
+            self._defocusRatio.set(self.DEFOCUS_RATIO_ERROR_VALUE)
 
     def equalAttributes(self, other, ignore=[], verbose=False):
         """ Override default behaviour to compare two


### PR DESCRIPTION
This PR includes:

- Changes in standardize method in CTFModel to protect from potential errors in defocus ratio calculation (division by cero)