### PR TITLE
only iterate over coords sets

### DIFF
--- a/pwem/protocols/protocol_particles_picking.py
+++ b/pwem/protocols/protocol_particles_picking.py
@@ -72,7 +72,7 @@ class ProtParticlePicking(ProtParticles):
                               self.getInputMicrographs().getSize()))
 
         if self.getOutputsSize() >= 1:
-            for key, output in self.iterOutputAttributes():
+            for key, output in self.iterOutputAttributes(emobj.SetOfCoordinates):
                 msg = self.getMethods(output)
                 methodsMsgs.append("%s: %s" % (self.getObjectTag(output), msg))
         else:


### PR DESCRIPTION
Fix methods. The reason is cryolo produces a boxSize integer output which gives an error for methods section.