### PR TITLE
link .gain as .tif file before conversion

### DIFF
--- a/pwem/emlib/image/image_handler.py
+++ b/pwem/emlib/image/image_handler.py
@@ -257,7 +257,7 @@ class ImageHandler(object):
                     'eman2.convert', 'getImageDimensions',
                     doRaise=True)
                 return getImageDimensions(fn)  # we are ignoring index here
-            elif ext == '.eer':
+            elif ext in ['.eer', '.gain']:
                 tif = TiffFile(fn)
                 frames = len(tif.pages)  # number of pages in the file
                 page = tif.pages[0]  # get shape and dtype of the image in the first page

--- a/pwem/protocols/protocol_movies.py
+++ b/pwem/protocols/protocol_movies.py
@@ -141,6 +141,13 @@ class ProtProcessMovies(ProtPreprocessMicrographs):
         elif not os.path.exists(finalName):
             # Conversion never happened...
             print('converting %s to %s' % (correctionImage, finalName))
+
+            if correctionImage.endswith('.gain'):  # treat as tif file
+                fnBase = basename(correctionImage)
+                tmpLink = self._getTmpPath(pwutils.replaceExt(fnBase, 'tif'))
+                pwutils.createAbsLink(correctionImage, tmpLink)
+                correctionImage = tmpLink
+
             emlib.image.ImageHandler().convert(correctionImage, finalName)
 
         # return final name


### PR DESCRIPTION
.gain gain reference file from Falcon 4 / EPU is a tif file. Since xmipp cant recognize it as tif (but rather unknown spider file), I make a tmp link before actual conversion to mrc. The link has to be absolute for cases when tmp is on separate scratch disc