### PR TITLE
add import coordinates from scipion to import coordiantes

### DIFF
--- a/pwem/protocols/protocol_import/dataimport.py
+++ b/pwem/protocols/protocol_import/dataimport.py
@@ -63,6 +63,28 @@ class ScipionImport:
         micSet.copyItems(inputSet, updateItemCallback=self._updateParticle)
         self.protocol._defineOutputs(outputMicrographs=micSet)
 
+    def importCoordinates(self, inputMics):
+        """ Import a SetOfCoordinates from a given sqlite file. """
+        inputSet = emobj.SetOfCoordinates(filename=self._sqliteFile)
+        # self._findImagesPath(inputSet)
+        
+        coorSet = self.protocol._createSetOfCoordinates(inputMics)
+        coorSet.copyInfo(inputSet)
+        coorSet.setObjComment('Coordinates imported from sqlite file:\n%s'
+                             % self._sqliteFile)
+
+        # Update both samplingRate and acquisition with parameters
+        # selected in the protocol form.
+        # Acquisition should be updated before, just to ensure that
+        # scannedPixedSize will be computed properly when calling
+        # setSamplingRate
+        coorSet.setBoxSize(self.protocol.boxSize.get())
+        # Read the micrographs from the 'self._sqliteFile' metadata
+        # but fixing the filenames with new ones (linked or copy to extraDir)
+        coorSet.copyItems(inputSet)
+        self.protocol._defineOutputs(outputCoordinates=coorSet)
+        self.protocol._defineSourceRelation(inputMics, coorSet)
+
     def importParticles(self):
         """ Import particles from a metadata 'images.xmd' """
         inputSet = emobj.SetOfParticles(filename=self._sqliteFile)

--- a/pwem/tests/protocols/test_protocols_import_coords.py
+++ b/pwem/tests/protocols/test_protocols_import_coords.py
@@ -72,6 +72,19 @@ class TestImportCoordinates(TestImportBase):
         # Make sure that all 264 coordinates where correctly imported
         self.assertTrue(prot1.outputCoordinates.getSize() == 264)
 
+        filepath = prot1.outputCoordinates.getFileName()
+        prot2 = self.newProtocol(emprot.ProtImportCoordinates,
+                                 importFrom=emprot.ProtImportCoordinates.IMPORT_FROM_SCIPION,
+                                 filesPath=filepath, 
+                                 filesPattern='',
+                                 boxSize=110,
+                                 )
+        prot2.inputMicrographs.set(protImport.outputMicrographs)
+        prot2.setObjLabel('import coords from scipion ')
+        self.launchProtocol(prot2)
+        # Make sure that all 264 coordinates where correctly imported
+        self.assertTrue(prot2.outputCoordinates.getSize() == 264)
+
         # prot2 = self.newProtocol(ProtImportCoordinates,
         #                          importFrom=ProtImportCoordinates.IMPORT_FROM_RELION,
         #                          filesPath=self.dsXmipp.getFile('boxingDir'),#no dataset with picking


### PR DESCRIPTION
Add to import coordinate protocol the option "import from scipion"

Test

scipion3 tests pwem.tests.protocols.test_protocols_import_coords.TestImportCoordinates

By the way this test checks import  coordinates from any package, therefore if some package is missing you will get an error. 