### PR TITLE
speed up potocol_sets

### DIFF
--- a/pwem/protocols/protocol_sets.py
+++ b/pwem/protocols/protocol_sets.py
@@ -32,13 +32,15 @@ This module contains protocols related to Set operations such us:
 """
 
 import random
+import sys
 
 import pyworkflow.protocol as pwprot
 import pyworkflow.object as pwobj
 
 import pwem.objects as emobj
 from pwem.protocols import EMProtocol
-from pwem.objects import Volume, EMSet
+from pwem.objects import Volume, EMset
+from pyworkflow.utils import ProgressBar
 
 
 class ProtSets(EMProtocol):
@@ -554,11 +556,30 @@ class ProtSubSet(ProtSets):
         outputSet.copyInfo(inputFullSet)
 
         if self.chooseAtRandom:
-            chosen = random.sample(range(len(inputFullSet)),
-                                   self.nElements.get())
+            nElementsFull = len(inputFullSet)
+            nElements = self.nElements.get()
+            chosen = random.sample(range(nElementsFull),
+                                   nElements)
+            doProgressBar = False
+            if nElementsFull > 100000:  # show progressBar for large sets
+                progress = ProgressBar(total=len(inputFullSet), fmt=ProgressBar.NOBAR)
+                progress.start()
+                sys.stdout.flush()
+                step = max(100, len(inputFullSet) // 100)
+                doProgressBar = True
+            j = 0  # index for chosen list
+            chosen.sort()  # sort list of numbers
             for i, elem in enumerate(inputFullSet):
-                if i in chosen:
-                    self._append(outputSet, elem)
+                if doProgressBar and (i % step == 0):
+                     progress.update(i+1)
+                if i == chosen[j]:
+                     j += 1
+                     outputSet.append(elem)
+                     if j >= nElements:
+                          break # all needed elements have been appended
+            if doProgressBar:
+                progress.finish()
+
         else:
             # Iterate over the elements in the smaller set
             # and take the info from the full set


### PR DESCRIPTION
The problem : I had a 4.500.000 particle set and I need to create several 100.000 random sets. In my computer each subset creation takes  3hours 16 minutes. After the attached modification this time goes down to 24 minutes (a factor of 10).

the key point is the loop:

                for i, elem in enumerate(inputFullSet):
                  if i in chosen:
                    self._append(outputSet, elem)

where chosen is a list with the random IDs I want to keep.  That is, for each element in the large set look in the list "chosen".
This loop is mush faster if chosen is first sorted.

j=0
              for i, elem in enumerate(inputFullSet):
+                if i == chosen[j]:
+                     j += 1
+                     outputSet.append(elem)
+                     if j >= nElements: # size output setOfparticles
+                          break # all needed elements have been appended

=====

In addition I have added a progressBar that is shown only for large datasets.
