### PR TITLE
test_workflow_xmipp_ctf_consensus.TestCtfConsensus Updated

### DIFF
--- a/pwem/tests/workflows/test_workflow_xmipp_ctf_consensus.py
+++ b/pwem/tests/workflows/test_workflow_xmipp_ctf_consensus.py
@@ -180,9 +180,9 @@ class TestCtfConsensus(pwtests.BaseTest):
 
         protCTF1.outputCTF.load()  # Needed to update the set
         protCTF2.outputCTF.load()  # Needed to update the set
-        ctfAveraged = {'defocusU': 24140.0898,
-                       'defocusV': 23569.0801,
-                       'defocusAngle': 58.3429}
+        ctfAveraged = {'defocusU': 24025.6729,
+                       'defocusV': 23610.2071,
+                       'defocusAngle': 57.1943}
         self.checkCTFs(protCTFcons3,
                        refMics=protImport.outputMicrographs,
                        refCTFs=protCTF1.outputCTF,


### PR DESCRIPTION
-Test_workflow_xmipp_ctf_consensus.py had three values regarding the CTF estimation (defocus U & V and Angle) that needed to be updated since the ctf estimation algorithms have change the way to estimate them. 