### PR TITLE
Possible output os movie alignment changed to dictionary.

### DIFF
--- a/pwem/protocols/protocol_align_movies.py
+++ b/pwem/protocols/protocol_align_movies.py
@@ -46,11 +46,10 @@ from pwem import emlib
 
 from pwem.protocols import ProtProcessMovies
 
-class ProtAlignMoviesOutput(enum.Enum):
-    """Pre-definition of outputs for movie alignments"""
-    outputMicrographs = emobj.SetOfMicrographs
-    outputMicrographsDoseWeighted = emobj.SetOfMicrographs
-    outputMovies =emobj.SetOfMovies
+OUT_MICS = "outputMicrographs"
+OUT_MICS_DW = "outputMicrographsDoseWeighted"
+OUT_MOVIES = "outputMovies"
+
 
 class ProtAlignMovies(ProtProcessMovies):
     """
@@ -61,7 +60,9 @@ class ProtAlignMovies(ProtProcessMovies):
     the frames range used for alignment and final sum, the binning factor
     or the cropping options (region of interest)
     """
-    _possibleOutputs = ProtAlignMoviesOutput
+    _possibleOutputs = dict({OUT_MICS: emobj.SetOfMicrographs,
+                             OUT_MICS_DW: emobj.SetOfMicrographs,
+                             OUT_MOVIES: emobj.SetOfMovies})
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
@@ -219,7 +220,7 @@ class ProtAlignMovies(ProtProcessMovies):
                                          "added to the output set.\n%s"
                                          % (movie.getFileName(), e)))
 
-            self._updateOutputSet(ProtAlignMoviesOutput.outputMovies.name, movieSet, streamMode)
+            self._updateOutputSet(OUT_MOVIES, movieSet, streamMode)
 
             if firstTime:
                 # Probably is a good idea to store a cached summary for the
@@ -273,12 +274,12 @@ class ProtAlignMovies(ProtProcessMovies):
         if self._createOutputMicrographs():
             _updateOutputMicSet('micrographs.sqlite',
                                 self._getOutputMicName,
-                                ProtAlignMoviesOutput.outputMicrographs.name)
+                                OUT_MICS)
 
         if self._createOutputWeightedMicrographs():
             _updateOutputMicSet('micrographs_dose-weighted.sqlite',
                                 self._getOutputMicWtName,
-                                ProtAlignMoviesOutput.outputMicrographsDoseWeighted.name)
+                                OUT_MICS_DW)
 
         if self.finished:  # Unlock createOutputStep if finished all jobs
             outputStep = self._getFirstJoinStep()


### PR DESCRIPTION
Turns out that Enum can't have two items with the same value and keep them separately.