### PR TITLE
fixed DataViewer for SetOfNormalModes

### DIFF
--- a/pwem/viewers/viewers_data.py
+++ b/pwem/viewers/viewers_data.py
@@ -231,4 +231,7 @@ class DataViewer(pwviewer.Viewer):
                 if os.path.exists(gainFn):
                     self._views.append(DataView(gainFn))
 
+        elif issubclass(cls, emobj.SetOfNormalModes):
+            self._views.append(DataView(obj.getFileName()))
+
         return self._views


### PR DESCRIPTION
Right-clicking a SetOfNormalModes gave an option to use the DataViewer because it was set as a target for it, but clicking that didn't do anything.

Now, I've added an entry to _visualize for that target so it works.