### PR TITLE
plotMatrix pass on kwargs

### DIFF
--- a/pwem/viewers/plotter.py
+++ b/pwem/viewers/plotter.py
@@ -122,7 +122,7 @@ class EmPlotter(Plotter):
                    , **kwargs):
         interpolation = kwargs.get('interpolation', "none")
         plot = img.imshow(matrix, interpolation=interpolation, cmap=cmap,
-                          vmin=vminData, vmax=vmaxData)
+                          vmin=vminData, vmax=vmaxData, **kwargs)
         if xticksLablesMajor is not None:
             plt.xticks(range(len(xticksLablesMajor)),
                        xticksLablesMajor[:len(xticksLablesMajor)],


### PR DESCRIPTION
This allows plotViewer to be given kwargs to get passed on to imshow. Previously, it could take kwargs but they weren't used anywhere. 

I showed it worked by giving origin='upper' in scipion-em-prody (line 103 of https://github.com/scipion-em/scipion-em-prody/blob/master/prody2/viewers/viewer_compare.py)