### PR TITLE
fixed fetch_emdb_map print error

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -544,7 +544,7 @@ def fetch_emdb_map(id, directory, tmpDirectory):
                                                           )
             break
         except Exception as e:
-            print("Retieving 3D map with id=", id, "failed retrying (%d/%d)" %
+            print("Retrieving 3D map with id=", id, "failed retrying (%d/%d)" %
                   (i+1, nTimes))
             print("Error:", e)
     # Loop statements may have an else clause; it is executed
@@ -571,7 +571,7 @@ def fetch_emdb_map(id, directory, tmpDirectory):
               "WARNING: origin  stored in EMDB\n"
               "database and 3D map header file do not match\n"
               "API=%f, header=%f\n"
-              "###########################\n" % (originAPI, originHeader))
+              "###########################\n" % (originAPI[0], originHeader[0]))
     return map_path, samplingAPI, originAPI
 
 


### PR DESCRIPTION
Using an old map, 2688, where the sampling rate isn't so well defined, I got the following error:
```
Scipion v3.0.10 - Eugenius
** Running command:  ipython 
Python 3.8.12 | packaged by conda-forge | (default, Oct 12 2021, 21:57:06) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pwem.protocols.protocol_import.volumes import fetch_emdb_map

In [2]: localFileName, sampling, origin = fetch_emdb_map(2688, directory='.', tmpDirectory='.')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-bc198a168cfc> in <module>
----> 1 localFileName, sampling, origin = fetch_emdb_map(2688, directory='.', tmpDirectory='.')

/mnt/c/Users/james/code/scipion3_new/scipion-em/pwem/protocols/protocol_import/volumes.py in fetch_emdb_map(id, directory, tmpDirectory)
    568 
    569     if norm(originHeader - originAPI) >= 0.1:
--> 570         print("###########################\n"
    571               "WARNING: origin  stored in EMDB\n"
    572               "database and 3D map header file do not match\n"

TypeError: only size-1 arrays can be converted to Python scalars
```

With the fix, everything works fine:
```
In [2]: localFileName, sampling, origin = fetch_emdb_map(2688, directory='.', tmpDirectory='.')
###########################
WARNING: origin  stored in EMDB
database and 3D map header file do not match
API=141.000000, header=140.600006
###########################


In [3]: localFileName, sampling, origin
Out[3]: ('./emd_2688.map', 1.41, array([141., 141., 141.]))
```

I also made a typo fix to one of the messages.