### PR TITLE
fetch_emdb_map fix for short ids

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -511,7 +511,7 @@ def fetch_emdb_map(id, directory, tmpDirectory):
     import socket
 
     # get computer name and select server
-    url_rest_api = "https://www.ebi.ac.uk/pdbe/api/emdb/entry/map/EMD-%d"
+    url_rest_api = "https://www.ebi.ac.uk/pdbe/api/emdb/entry/map/EMD-%s"
     hname = socket.gethostname()
     if hname.endswith('.edu') or hname.endswith('.gov'):
         site = 'ftp.wwpdb.org'
@@ -523,10 +523,15 @@ def fetch_emdb_map(id, directory, tmpDirectory):
         site = 'ftp.ebi.ac.uk'
         url_pattern = 'ftp://%s/pub/databases/emdb/structures/EMD-%s/map/%s'
 
+    if len(str(id)) < 4:
+        id = '%04d' % id
+    else:
+        id = '%d' % id
+
     map_name = 'emd_%s.map' % id
     map_gz_name = map_name + '.gz'
     map_url = url_pattern % (site, id, map_gz_name)
-    name = 'EMD-%d' % id
+    name = 'EMD-%s' % id
     minimum_map_size = 8192  # bytes
     url_rest_api = url_rest_api % id
 


### PR DESCRIPTION
EMDB entries with IDs shorter than 4 characters have prepending zeros e.g. 0774 so we need to take that into account to fetch them. Without the fix, I get the following error:
```
localFileName, sampling, origin = fetch_emdb_map(774, directory='.', tmpDirectory='.')
Error retrieving data from EMDB <urlopen error ftp error: error_perm('550 Failed to change directory.')>
Retrieving 3D map with id= 774 failed retrying (1/3)
Error: [Errno 2] No such file or directory: './emd_774.map.gz'
Error retrieving data from EMDB <urlopen error ftp error: error_perm('550 Failed to change directory.')>
Retrieving 3D map with id= 774 failed retrying (2/3)
Error: [Errno 2] No such file or directory: './emd_774.map.gz'
Error retrieving data from EMDB <urlopen error ftp error: error_perm('550 Failed to change directory.')>
Retrieving 3D map with id= 774 failed retrying (3/3)
Error: [Errno 2] No such file or directory: './emd_774.map.gz'
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-4-a8125c55054d> in <module>
----> 1 localFileName, sampling, origin = fetch_emdb_map(774, directory='.', tmpDirectory='.')

/mnt/c/Users/james/code/scipion3_new/scipion-em/pwem/protocols/protocol_import/volumes.py in fetch_emdb_map(id, directory, tmpDirectory)
    551     # when the loop terminates through exhaustion of the iterable
    552     else:
--> 553         raise Exception("Cannot retrieve File from EMDB")
    554 
    555 

Exception: Cannot retrieve File from EMDB
```

The same behaviour is seen in scipion itself.

With the fix, such files are downloaded fine. It seems to take a while but that may be big my example is 400 x 400 x 400 voxels.
