### PR TITLE
Update viewer_sequence.py

### DIFF
--- a/pwem/viewers/viewer_sequence.py
+++ b/pwem/viewers/viewer_sequence.py
@@ -62,8 +62,13 @@ class SequenceViewer(pwviewer.Viewer):
         seqID = obj.getId() if obj.getId() is not None else 'seqID'
         seqName = obj.getSeqName() if obj.getSeqName() is not None else 'sequence'
         seqDescription = obj.getDescription() if obj.getDescription() is not None else ''
-        seqFileName = os.path.abspath(
-            self.protocol._getExtraPath(seqName + ".fasta"))
+        # check if protocol has created directory extructura, if not use /tmp
+        extraDir = self.protocol._getExtraPath() 
+        if os.path.isdir(extraDir):
+            seqFileName = os.path.abspath(
+                self.protocol._getExtraPath(seqName + ".fasta"))
+        else:
+            seqFileName = os.path.abspath(os.path.join("/tmp", seqName + ".fasta"))
         # Step 3: Sequence saved in the extra file
         seqHandler.saveFile(seqFileName, seqID, sequence=seqBio,
                             name=seqName, seqDescription=seqDescription,


### PR DESCRIPTION
Sequence viewer fails if protocol directory structure does not exist. 
Therefore, check if "extra" directory exists before saving the sequence and if it does not exist then use /tmp.

When is this important?
1) open a new protocol that uses a sequence as input
2) select sequence
3) click eye to see sequence

viewer fails because it tries to create a file in the extra dir but that dir does not exist yet.