### PR TITLE
pass parameter "self.threshold" to the viewer

### DIFF
--- a/pwem/viewers/viewer_fsc.py
+++ b/pwem/viewers/viewer_fsc.py
@@ -118,7 +118,7 @@ class FscViewer(pwviewer.Viewer):
             a.grid(True)
             a.xaxis.set_major_formatter(FuncFormatter(self._formatFreq))
             self._lastSubPlot = a
-        resolution = obj.calculateResolution()
+        resolution = obj.calculateResolution(self.threshold)
         self.label = kwargs.get('label', self.protocol.getRunName()) + " (" + str(resolution) + "Å)"
         self.plotter.plotData(x, y, '-', label=self.label)
         self.plotter.legend()


### PR DESCRIPTION
In the present implementation, the function calculateResolution() (line 121) does not pass the threshold parameter. Therefore, the default value 0.143 is always used. 
Not passing the threshold value have two effects:

1) the user cannot select it
2) the viewer will not draw the plot if the value of the FSC for all points is always greater than 0.143