### PR TITLE
Protocol boxsize related parameters outputs even number values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+V3.0.17
+users:
+   - Updating protocol box size related parameters. Now for sanity reasons, it outputs only even numbers.
+
 V3.0.16
 users:
    - Fixing an error calculating the FSC resolution value. 

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -40,7 +40,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.0.16'
+__version__ = '3.0.17'
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/pwem/protocols/protocol_boxsize_parameters.py
+++ b/pwem/protocols/protocol_boxsize_parameters.py
@@ -227,7 +227,6 @@ class ProtBoxSizeParameters(EMProtocol):
         Applies the formula to each of the parameters selected by the user.
         """
 
-        boxSize = transform2EvenNumber(boxSize)
         self.registerEvenBoxSize(boxSize)
 
         if self.boolExtractPartBx.get():
@@ -251,6 +250,7 @@ class ProtBoxSizeParameters(EMProtocol):
         self.outputsToDefine[outputName] = value
 
     def registerEvenBoxSize(self, boxSize):
+        boxSize = transform2EvenNumber(boxSize)
         self.registerOutput(BOXSIZE_EVEN, Integer(boxSize))
 
     def calculateParticleExtractionParams(self, boxSize):
@@ -305,8 +305,7 @@ class ProtBoxSizeParameters(EMProtocol):
 
 
 def transform2EvenNumber(var):
-    var = round(var)
     if var % 2 != 0:
-        var = var + 1
+        var = round(var / 2) * 2
 
     return var

--- a/pwem/tests/protocols/test_protocol_boxsize_parameters.py
+++ b/pwem/tests/protocols/test_protocol_boxsize_parameters.py
@@ -74,15 +74,15 @@ class TestBoxSizeParameters(BaseTest):
         prot = self._runBoxSizeParamsTestExtrGaut(label='Picking box size related parameters'
                                                                            ' extraction and gautomatch')
 
-        self.assertEqual(prot.boxSizeExtraction, 103, "Estimated box size extraction does not match.")
-        self.assertEqual(prot.radiusGautomatch, 183, "Estimated radius for "
+        self.assertEqual(prot.boxSizeExtraction, 106, "Estimated box size extraction does not match.")
+        self.assertEqual(prot.radiusGautomatch, 186, "Estimated radius for "
                                                                         "gautomatch does not match.")
-        self.assertEqual(prot.minIntPartDistanceGautomatch, 219, "Estimated min inter "
+        self.assertEqual(prot.minIntPartDistanceGautomatch, 224, "Estimated min inter "
                                                                                     "particle distance for gautomatch "
                                                                                     "does not match.")
-        self.assertEqual(prot.sigmaDiameterGautomatch, 293, "Estimated sigma diameter for "
+        self.assertEqual(prot.sigmaDiameterGautomatch, 298, "Estimated sigma diameter for "
                                                                                "gautomatch does not match.")
-        self.assertEqual(prot.averageDiameterGautomatch, 366, "Estimated average diameter "
+        self.assertEqual(prot.averageDiameterGautomatch, 372, "Estimated average diameter "
                                                                                  "for gautomatch does not match.")
 
     def testBoxSizeParametersRelionTopazConsensus(self):
@@ -90,12 +90,12 @@ class TestBoxSizeParameters(BaseTest):
         prot = self._runBoxSizeParamsTestRelionTopazConsensus(label='Picking box size related parameters '
                                                                     'relion, topaz and radius consensus')
 
-        self.assertEqual(prot.minLoGFilterRelion, 232, "Estimated minLoGFilterRelion for relion does not match.")
-        self.assertEqual(prot.maxLoGFilterRelion, 256, "Estimated maxLoGFilterRelion for relion does not match.")
-        self.assertEqual(prot.radiusTopaz, 31, "Estimated radius for topaz does not match.")
+        self.assertEqual(prot.minLoGFilterRelion, 236, "Estimated minLoGFilterRelion for relion does not match.")
+        self.assertEqual(prot.maxLoGFilterRelion, 260, "Estimated maxLoGFilterRelion for relion does not match.")
+        self.assertEqual(prot.radiusTopaz, 32, "Estimated radius for topaz does not match.")
         self.assertEqual(prot.numPartPerImgTopaz, 300, "Estimated average diameter numPartPerImgTopaz "
                                                        "for topaz does not match.")
-        self.assertEqual(prot.radiusConsensus, 62, "Estimated radius for picking consensus does not match.")
+        self.assertEqual(prot.radiusConsensus, 64, "Estimated radius for picking consensus does not match.")
 
     def _runBoxSizeParamsTestExtrGaut(cls, label):
         protBoxSizeParams = cls.newProtocol(ProtBoxSizeParameters,

--- a/pwem/tests/protocols/test_protocol_boxsize_parameters.py
+++ b/pwem/tests/protocols/test_protocol_boxsize_parameters.py
@@ -74,15 +74,15 @@ class TestBoxSizeParameters(BaseTest):
         prot = self._runBoxSizeParamsTestExtrGaut(label='Picking box size related parameters'
                                                                            ' extraction and gautomatch')
 
-        self.assertEqual(prot.boxSizeExtraction, 106, "Estimated box size extraction does not match.")
-        self.assertEqual(prot.radiusGautomatch, 186, "Estimated radius for "
+        self.assertEqual(prot.boxSizeExtraction, 102, "Estimated box size extraction does not match.")
+        self.assertEqual(prot.radiusGautomatch, 180, "Estimated radius for "
                                                                         "gautomatch does not match.")
-        self.assertEqual(prot.minIntPartDistanceGautomatch, 224, "Estimated min inter "
+        self.assertEqual(prot.minIntPartDistanceGautomatch, 216, "Estimated min inter "
                                                                                     "particle distance for gautomatch "
                                                                                     "does not match.")
-        self.assertEqual(prot.sigmaDiameterGautomatch, 298, "Estimated sigma diameter for "
+        self.assertEqual(prot.sigmaDiameterGautomatch, 288, "Estimated sigma diameter for "
                                                                                "gautomatch does not match.")
-        self.assertEqual(prot.averageDiameterGautomatch, 372, "Estimated average diameter "
+        self.assertEqual(prot.averageDiameterGautomatch, 362, "Estimated average diameter "
                                                                                  "for gautomatch does not match.")
 
     def testBoxSizeParametersRelionTopazConsensus(self):
@@ -90,12 +90,12 @@ class TestBoxSizeParameters(BaseTest):
         prot = self._runBoxSizeParamsTestRelionTopazConsensus(label='Picking box size related parameters '
                                                                     'relion, topaz and radius consensus')
 
-        self.assertEqual(prot.minLoGFilterRelion, 236, "Estimated minLoGFilterRelion for relion does not match.")
-        self.assertEqual(prot.maxLoGFilterRelion, 260, "Estimated maxLoGFilterRelion for relion does not match.")
-        self.assertEqual(prot.radiusTopaz, 32, "Estimated radius for topaz does not match.")
+        self.assertEqual(prot.minLoGFilterRelion, 228, "Estimated minLoGFilterRelion for relion does not match.")
+        self.assertEqual(prot.maxLoGFilterRelion, 252, "Estimated maxLoGFilterRelion for relion does not match.")
+        self.assertEqual(prot.radiusTopaz, 30, "Estimated radius for topaz does not match.")
         self.assertEqual(prot.numPartPerImgTopaz, 300, "Estimated average diameter numPartPerImgTopaz "
                                                        "for topaz does not match.")
-        self.assertEqual(prot.radiusConsensus, 64, "Estimated radius for picking consensus does not match.")
+        self.assertEqual(prot.radiusConsensus, 62, "Estimated radius for picking consensus does not match.")
 
     def _runBoxSizeParamsTestExtrGaut(cls, label):
         protBoxSizeParams = cls.newProtocol(ProtBoxSizeParameters,


### PR DESCRIPTION
This was done for sanity check since some of the output parameters where sensible to this condition (i.e. box size in 2D Classification). 