### PR TITLE
Variable wizard

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,8 @@ users:
       
 developers:
    - New method at pwem/convert/headers.setMRCSamplingRate: sets the sampling rate of an mrc file. Image Object has it: volume.setMRCSamplingRate(3.5) should work.
-   - protcols.conf minimized only containig its own protocols 
+   - protcols.conf minimized only containig its own protocols
+   - Variable wizard with customizable target, input and output parameters
 
 
 V3.0.15

--- a/pwem/constants.py
+++ b/pwem/constants.py
@@ -168,3 +168,10 @@ FREQ_BANDPASS_WIZ_MSG = \
 EM_ROOT_VAR = 'EM_ROOT'
 
 DEFAULT_MAX_PREVIEW_FILE_SIZE = 500  # Unit is MB: 500 MB
+
+RESIDUES3TO1 = {'CYS': 'C', 'ASP': 'D', 'SER': 'S', 'GLN': 'Q', 'LYS': 'K',
+               'ILE': 'I', 'PRO': 'P', 'THR': 'T', 'PHE': 'F', 'ASN': 'N',
+               'GLY': 'G', 'HIS': 'H', 'LEU': 'L', 'ARG': 'R', 'TRP': 'W',
+               'ALA': 'A', 'VAL':'V', 'GLU': 'E', 'TYR': 'Y', 'MET': 'M'}
+
+RESIDUES1TO3 = {v: k for k, v in RESIDUES3TO1.items()}

--- a/pwem/wizards/wizard.py
+++ b/pwem/wizards/wizard.py
@@ -159,8 +159,34 @@ class VariableWizard(pwizard.Wizard):
         for target in self._targets:
             if form.wizParamName == target[1][0] and form.protocol.__class__ == target[0]:
                 prot, target = (target[0], target[1][0])
-                inParam, outParam = self._inputs[(prot, target)], self._outputs[(prot, target)]
-        return inParam, outParam
+                inParams, outParam = self._inputs[(prot, target)], self._outputs[(prot, target)]
+                inParams = self.filterPresentInputs(inParams, form.protocol)
+        return inParams, outParam
+
+    def filterPresentInputs(self, inputParams, protocol):
+        '''Filter the inputs to allow flexibility:
+        1) InputParams can be lists: the first not None parameter of the list will be chosen.
+        2) InputParams can be dict: key -> EnumParam (or IntParam) which functions as index
+                                    value -> list containing paramNames. The hey index element will be chosen
+        '''
+        fInpParams = []
+        for inPar in inputParams:
+            if type(inPar) == list:
+                present = ''
+                for option in inPar:
+                    if getattr(protocol, option).get():
+                        present = option
+                        break
+                fInpParams.append(present)
+            elif type(inPar) == dict:
+                idxParam = list(inPar.keys())[0]
+                optionParams = inPar[idxParam]
+
+                idx = getattr(protocol, idxParam).get()
+                fInpParams.append(optionParams[idx])
+            else:
+                fInpParams.append(inPar)
+        return fInpParams
 
 class DownsampleWizard(EmWizard):
 

--- a/pwem/wizards/wizard.py
+++ b/pwem/wizards/wizard.py
@@ -139,6 +139,29 @@ class EmWizard(pwizard.Wizard):
 #    Wizards base classes
 # ===============================================================================
 
+class VariableWizard(pwizard.Wizard):
+    """Wizard base class object where input and output paramNames can be modified and added, so
+    one wizard can be used in several protocols with parameters of different names"""
+    #Variables _targets, _inputs and _outputs must be created in sons
+    # _targets, _inputs, _outputs = [], {}, {}
+
+    def addTarget(self, protocol, targets, inputs, outputs):
+        '''Add a target to a wizard and the input and output parameters are stored in a dictionary with
+        (protocol, targetParamName) as key.
+        Targets must be added one by one.'''
+        self._targets += [(protocol, targets)]
+        self._inputs.update({(protocol, targets[0]): inputs})
+        self._outputs.update({(protocol, targets[0]): outputs})
+
+    def getInputOutput(self, form):
+        '''Retrieving input and output paramNames corresponding to the protocol and target of the wizard clicked'''
+        outParam = ''
+        for target in self._targets:
+            if form.wizParamName == target[1][0] and form.protocol.__class__ == target[0]:
+                prot, target = (target[0], target[1][0])
+                inParam, outParam = self._inputs[(prot, target)], self._outputs[(prot, target)]
+        return inParam, outParam
+
 class DownsampleWizard(EmWizard):
 
     def show(self, form, value, label, units=emcts.UNIT_PIXEL):

--- a/pwem/wizards/wizards.py
+++ b/pwem/wizards/wizards.py
@@ -299,25 +299,10 @@ class PythonFormulaeWizard(pwizard.Wizard):
         if d.resultYes():
             form.setVar('formula',d.getFormula())
             
-class SelectAttributeWizard(pwizard.Wizard):
-  """Base wizard for selecting an attribute from those contained in the items of a given input
-  inputParam: Name of the input parameter where the items are stored
-  outputParam:
+class SelectAttributeWizard(VariableWizard):
+  """Wizard to select attributes stored in a scipion object or set
   """
   _targets, _inputs, _outputs = [], {}, {}
-
-  def addTarget(self, protocol, targets, inputs, outputs):
-      self._targets += [(protocol, targets)]
-      self._inputs.update({protocol: inputs})
-      self._outputs.update({protocol: outputs})
-
-  def getInputOutput(self, form):
-      '''Retrieving input and output corresponding to the protocol where the wizard is used'''
-      outParam = ''
-      for target in self._targets:
-          if form.protocol.__class__ == target[0]:
-              inParam, outParam = self._inputs[target[0]], self._outputs[target[0]]
-      return inParam, outParam
 
   def getFirstItem(self, form, inputParam):
       inputPointer = getattr(form.protocol, inputParam)

--- a/pwem/wizards/wizards.py
+++ b/pwem/wizards/wizards.py
@@ -27,7 +27,7 @@
 """ This module is for Actual wizards to be able to be discovered from the
 Domain. wizard.py is left for wizard models and base classes."""
 import decimal
-import os
+import os, json
 import requests
 
 import pyworkflow.object as pwobj
@@ -37,10 +37,11 @@ from pyworkflow.gui.tree import ListTreeProviderString
 
 import pwem.convert as emconv
 
-from pwem.wizards.wizard import EmWizard, FormulaDialog, ColorScaleWizardBase
+from pwem.wizards.wizard import EmWizard, FormulaDialog, ColorScaleWizardBase, VariableWizard
 import pwem.protocols as emprot
 import pwem.viewers as emview
 import pwem.objects as emobj
+from pwem.constants import RESIDUES3TO1, RESIDUES1TO3
 
 
 class ImportAcquisitionWizard(EmWizard):
@@ -159,26 +160,23 @@ class ChangeOriginSamplingWizard(pwizard.Wizard):
         form.setVar('samplingRate', round(sampling, 3))
 
 
-class GetStructureChainsWizard(pwizard.Wizard):
-    """Load an atomic structure, parse chain related information as
-       name, number of residues, list of aminoacids (or other residues)"""
-    _targets = [(emprot.ProtImportSequence, ['inputStructureChain'])
-                # NOTE: be careful if you change this class since
-                # chimera-wizard inherits from it.
-                # (ChimeraModelFromTemplate, ['inputStructureChain'])
-                # (atomstructutils, ['inputStructureChain'])
-                ]
+class SelectChainWizard(VariableWizard):
+    '''Opens the input AtomStruct and allows you to select one of the present chains'''
+    _targets, _inputs, _outputs = [], {}, {}
 
     @classmethod
-    def getModelsChainsStep(cls, protocol):
+    def getModelsChainsStep(cls, protocol, inputParamName):
         """ Returns (1) list with the information
            {"model": %d, "chain": "%s", "residues": %d} (modelsLength)
            (2) list with residues, position and chain (modelsFirstResidue)"""
         structureHandler = emconv.AtomicStructHandler()
         fileName = ""
-        if hasattr(protocol, 'pdbId'):
-            if protocol.pdbId.get() is not None:
-                pdbID = protocol.pdbId.get()
+        AS = getattr(protocol, inputParamName).get()
+        if type(AS) == str:
+            if os.path.exists(AS):
+                fileName = AS
+            else:
+                pdbID = AS
                 url = "https://www.rcsb.org/structure/"
                 URL = url + ("%s" % pdbID)
                 try:
@@ -187,45 +185,106 @@ class GetStructureChainsWizard(pwizard.Wizard):
                     raise Exception("Cannot connect to PDB server")
                 if (response.status_code >= 400) and (response.status_code < 500):
                     raise Exception("%s is a wrong PDB ID" % pdbID)
-                fileName = structureHandler.readFromPDBDatabase(
-                    os.path.basename(pdbID), dir="/tmp/")
-            else:
-                fileName = protocol.pdbFile.get()
+                fileName = structureHandler.readFromPDBDatabase(os.path.basename(pdbID), dir="/tmp/")
+
+        elif str(type(AS).__name__) == 'SchrodingerAtomStruct':
+            fileName = os.path.abspath(AS.convert2PDB())
         else:
-            if protocol.pdbFileToBeRefined.get() is not None:
-                fileName = os.path.abspath(protocol.pdbFileToBeRefined.get(
-                ).getFileName())
+            fileName = os.path.abspath(AS.getFileName())
 
         structureHandler.read(fileName)
         structureHandler.getStructure()
-        # listOfChains, listOfResidues = structureHandler.getModelsChains()
         return structureHandler.getModelsChains()
 
     def editionListOfChains(self, listOfChains):
-        self.chainList = []
+        chainList = []
         for model, chainDic in listOfChains.items():
             for chainID, lenResidues in chainDic.items():
-                self.chainList.append(
+                chainList.append(
                     '{"model": %d, "chain": "%s", "residues": %d}' %
                     (model, str(chainID), lenResidues))
+        return chainList
 
     def show(self, form, *params):
+        inputParams, outputParam = self.getInputOutput(form)
         protocol = form.protocol
         try:
-            listOfChains, listOfResidues = self.getModelsChainsStep(protocol)
+            listOfChains, listOfResidues = self.getModelsChainsStep(protocol, inputParams[0])
         except Exception as e:
             print("ERROR: ", e)
             return
 
-        self.editionListOfChains(listOfChains)
+        chainList = self.editionListOfChains(listOfChains)
         finalChainList = []
-        for i in self.chainList:
+        for i in chainList:
             finalChainList.append(pwobj.String(i))
         provider = ListTreeProviderString(finalChainList)
         dlg = dialog.ListDialog(form.root, "Model chains", provider,
                                 "Select one of the chains (model, chain, "
                                 "number of chain residues)")
-        form.setVar('inputStructureChain', dlg.values[0].get())
+        form.setVar(outputParam[0], dlg.values[0].get())
+
+SelectChainWizard().addTarget(protocol=emprot.ProtImportSequence,
+                              targets=['inputStructureChain'],
+                              inputs=[['pdbId', 'pdbFile']],
+                              outputs=['inputStructureChain'])
+
+class SelectResidueWizard(SelectChainWizard):
+    _targets, _inputs, _outputs = [], {}, {}
+
+    def editionListOfResidues(self, modelsFirstResidue, model, chain):
+      residueList = []
+      for modelID, chainDic in modelsFirstResidue.items():
+        if int(model) == modelID:
+          for chainID, seq_number in chainDic.items():
+            if chain == chainID:
+              for i in seq_number:
+                residueList.append('{"index": %d, "residue": "%s"}' % (i[0], str(i[1])))
+      return residueList
+
+    def getResidues(self, form, inputParams):
+      protocol = form.protocol
+      inputObj = getattr(protocol, inputParams[0]).get()
+      if issubclass(type(inputObj), emobj.AtomStruct):
+          try:
+            modelsLength, modelsFirstResidue = self.getModelsChainsStep(protocol, inputParams[0])
+          except Exception as e:
+            print("ERROR: ", e)
+            return
+          selection = getattr(protocol, inputParams[1]).get()
+          struct = json.loads(selection)  # From wizard dictionary
+          chain, model = struct["chain"].upper().strip(), int(struct["model"])
+
+          residueList = self.editionListOfResidues(modelsFirstResidue, model, chain)
+          finalResiduesList = []
+          for i in residueList:
+            finalResiduesList.append(emobj.String(i))
+
+      elif issubclass(type(inputObj), emobj.Sequence) or str(type(AS).__name__) == 'SequenceVariants':
+          finalResiduesList = []
+          for i, res in enumerate(inputObj.getSequence()):
+            stri = '{"index": %s, "residue": "%s"}' % (i + 1, RESIDUES1TO3[res])
+            finalResiduesList.append(emobj.String(stri))
+
+      return finalResiduesList
+
+    def show(self, form, *params):
+      inputParams, outputParam = self.getInputOutput(form)
+      finalResiduesList = self.getResidues(form, inputParams)
+
+      provider = ListTreeProviderString(finalResiduesList)
+      dlg = dialog.ListDialog(form.root, "Chain residues", provider,
+                              "Select one residue (residue number, "
+                              "residue name)")
+      roiStr = ''
+      idxs = [json.loads(dlg.values[0].get())['index'], json.loads(dlg.values[-1].get())['index']]
+      for i in range(idxs[0] - 1, idxs[1]):
+        roiStr += RESIDUES3TO1[json.loads(finalResiduesList[i].get())['residue']]
+
+      intervalStr = '{"index": "%s-%s", "residues": "%s"}' % (idxs[0], idxs[1], roiStr)
+      form.setVar(outputParam[0], intervalStr)
+
+
 
 class PythonFormulaeWizard(pwizard.Wizard):
     """Assist in the creation of python formula to be evaluated. In Steps"""


### PR DESCRIPTION
Variable wizard with customizable target, input and output parameters. 
Gives flexibility, avoiding unnecessary inheritances just for changing param names
Example of the functioning with the replacement of the current wizard for selecting structure chains and residues (uses of the previous wizard corrected in other plugins respective PR)