### PR TITLE
add number to SetOfAS localPath to fix overwriting

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -473,24 +473,24 @@ class ProtImportSetOfAtomStructs(ProtImportFiles):
       padding_format_str = '%0' + str(len(str(numStructs))) + 'd'
 
       for atomStructPath in atomStructPaths:
-        if not exists(atomStructPath):
-          raise Exception("Atomic structure not found at *%s*" % atomStructPath)
+          if not exists(atomStructPath):
+              raise Exception("Atomic structure not found at *%s*" % atomStructPath)
 
-        baseName = basename(atomStructPath)
-        localPath = abspath(self._getExtraPath(baseName))
+          baseName = basename(atomStructPath)
+          localPath = abspath(self._getExtraPath(baseName))
 
-        if str(atomStructPath) != str(localPath):  # from local file
-          if exists(localPath):
-            localPath = splitext(localPath)[0] + padding_format_str % (i+1) + splitext(localPath)[1]
-            i += 1
-          else:
-            i = 0
+          if str(atomStructPath) != str(localPath):  # from local file
+              if exists(localPath):
+                  localPath = splitext(localPath)[0] + padding_format_str % (i+1) + splitext(localPath)[1]
+                  i += 1
+              else:
+                  i = 0
                   
           pwutils.copyFile(atomStructPath, localPath)
 
-        localPath = relpath(localPath)
+          localPath = relpath(localPath)
 
-        outASs.append(emobj.AtomStruct(filename=localPath))
+          outASs.append(emobj.AtomStruct(filename=localPath))
 
       self._defineOutputs(**{self._OUTNAME:outASs})
 

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -26,7 +26,7 @@
 # **************************************************************************
 
 
-from os.path import exists, basename, abspath, relpath, join
+from os.path import exists, basename, abspath, relpath, join, splitext
 from os import stat
 from numpy import array
 from numpy.linalg import norm
@@ -468,19 +468,29 @@ class ProtImportSetOfAtomStructs(ProtImportFiles):
       """ Copy the PDB structures and register the output object.
       """
       outASs = emobj.SetOfAtomStructs().create(self._getPath())
+      
+      numStructs = len(atomStructPaths)
+      padding_format_str = '%0' + str(len(str(numStructs))) + 'd'
+
       for atomStructPath in atomStructPaths:
-          if not exists(atomStructPath):
-              raise Exception("Atomic structure not found at *%s*" % atomStructPath)
+        if not exists(atomStructPath):
+          raise Exception("Atomic structure not found at *%s*" % atomStructPath)
 
-          baseName = basename(atomStructPath)
-          localPath = abspath(self._getExtraPath(baseName))
+        baseName = basename(atomStructPath)
+        localPath = abspath(self._getExtraPath(baseName))
 
-          if str(atomStructPath) != str(localPath):  # from local file
-              pwutils.copyFile(atomStructPath, localPath)
+        if str(atomStructPath) != str(localPath):  # from local file
+          if exists(localPath):
+            localPath = splitext(localPath)[0] + padding_format_str % (i+1) + splitext(localPath)[1]
+            i += 1
+          else:
+            i = 0
+                  
+          pwutils.copyFile(atomStructPath, localPath)
 
-          localPath = relpath(localPath)
+        localPath = relpath(localPath)
 
-          outASs.append(emobj.AtomStruct(filename=localPath))
+        outASs.append(emobj.AtomStruct(filename=localPath))
 
       self._defineOutputs(**{self._OUTNAME:outASs})
 

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -486,7 +486,7 @@ class ProtImportSetOfAtomStructs(ProtImportFiles):
               else:
                   i = 0
                   
-          pwutils.copyFile(atomStructPath, localPath)
+              pwutils.copyFile(atomStructPath, localPath)
 
           localPath = relpath(localPath)
 


### PR DESCRIPTION
If there are different folders with atomic structure files with the same name that get selected with wild cards then they would overwrite each other previously. 

Now, if there's already something with that name then we add a number e.g. atoms.pdb becomes atoms2.pdb if atoms.pdb is already there. 