### PR TITLE
JMK added SetOfPrincipalComponents

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -2142,6 +2142,11 @@ class SetOfNormalModes(EMSet):
         self._pdbPointer.copy(other._pdbPointer, copyId=False)
 
 
+class SetOfPrincipalComponents(SetOfNormalModes):
+    "Set of Principal Components is a SetOfNormalModes with a new name"
+    pass
+
+
 class FramesRange(CsvList):
     """ Store first and last frames in a movie. The last element will be
      the index in the stack of the first frame.

--- a/pwem/viewers/viewers_data.py
+++ b/pwem/viewers/viewers_data.py
@@ -55,6 +55,7 @@ class DataViewer(pwviewer.Viewer):
         emobj.SetOfImages,
         emobj.SetOfMovies,
         emobj.SetOfNormalModes,
+        emobj.SetOfPrincipalComponents,
         emobj.SetOfPDBs,
         emprot.ProtParticlePicking,
         emprot.ProtImportMovies,


### PR DESCRIPTION
This object is just a way of giving outputs a clearer name for better interpretation of results

Principal components aren't really that different from normal modes. The way of calculating them is different and the eigenvalues are the variance not its inverse, but that's all.

I now have a PCA protocol and pipeline and also some handling of eigenvalue order in the import modes protocol too: https://github.com/scipion-em/scipion-em-prody/pull/26