### PR TITLE
Missing include basic

### DIFF
--- a/pwem/protocols/protocol_sets.py
+++ b/pwem/protocols/protocol_sets.py
@@ -256,8 +256,9 @@ class ProtUnionSet(ProtSets):
                 self.cleanExtraAttributes(value, verifyAttrs,
                                           prefixedAttribute + ".")
 
-    def getObjDict(self, includeClass=False):
-        return super(ProtUnionSet, self).getObjDict(includeClass)
+    def getObjDict(self, includeClass=False, includeBasic=False):
+        return super(ProtUnionSet, self).getObjDict(
+            includeClass=includeClass, includeBasic=includeBasic)
 
     def duplicatedIds(self):
         """ Check if there are duplicated ids to renumber from


### PR DESCRIPTION
Missing 'includeBasic' parameter in overwritten method from base class. 