### PR TITLE
  - Allow indirect pointers in SetOfClasses.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,15 @@
-V3.0.19
+V3.0.20
 users:
    - New protocol: Mathematical operator.
+   - Import coordinates fixed for complex streaming cases.
+   - Extract particles does not need SetOfMicrographs is "same as coordinates" is used.
 developers:
    - Methods to guess the cuda version from a variable that point to a folder in Plugin class:
     (Plugin.guessCudaVersion(varname)). Follows links.
+   - Allow indirect pointers in SetOfClasses.
+   - Warning added in SetOfCoordinates.setMicrographs when not using an indirect pointer.
+   - Warning added in SetOfClasses.setImages when not using an indirect pointer.
+   - data.py test_workflow_mixed.py and uses logger instead of print
 
 V3.0.19
 users:

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1359,13 +1359,24 @@ class SetOfParticles(SetOfImages):
         """ Set the SetOfCoordinates associates with
         this set of particles.
          """
-        self._coordsPointer.set(coordinates)
+        if coordinates.isPointer():
+            self._coordsPointer.copy(coordinates)
+        else:
+            self._coordsPointer.set(coordinates)
+
+        if not self._coordsPointer.hasExtended():
+            logger.warning("FOR DEVELOPERS: Direct pointers to objects should be avoided. "
+                           "They are problematic in complex streaming scenarios. "
+                           "Pass a pointer to a protocol with extended "
+                           "(e.g.: input param are this kind of pointers. Without get()!)")
+
 
     def copyInfo(self, other):
         """ Copy basic information (voltage, spherical aberration and
         sampling rate) from other set of micrographs to current one.
         """
         SetOfImages.copyInfo(self, other)
+        self.copyAttributes(other, "_coordsPointer")
         self.setHasCTF(other.hasCTF())
 
 
@@ -1923,6 +1934,10 @@ class SetOfClasses(EMSet):
     def getImages(self):
         """ Return the SetOFImages used to create the SetOfClasses. """
         return self._imagesPointer.get()
+
+    def getImagesPointer(self):
+        """" Return the pointer to the SetOFImages used to create the SetOfClasses. """
+        return self._imagesPointer
 
     def setImages(self, images):
         """ Set the images (particles 2d associated with this set of classes.

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1376,7 +1376,8 @@ class SetOfParticles(SetOfImages):
         sampling rate) from other set of micrographs to current one.
         """
         SetOfImages.copyInfo(self, other)
-        self.copyAttributes(other, "_coordsPointer")
+        if hasattr(other, '_coordsPointer'):
+            self.copyAttributes(other, "_coordsPointer")
         self.setHasCTF(other.hasCTF())
 
 

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -28,6 +28,8 @@
 This modules contains basic hierarchy
 for EM data objects like: Image, SetOfImage and others
 """
+import logging
+logger = logging.getLogger(__name__)
 
 import os
 import json
@@ -1245,7 +1247,7 @@ class SetOfImages(EMSet):
         sampling = self.getSamplingRate()
 
         if not sampling:
-            print("FATAL ERROR: Object %s has no sampling rate!!!"
+            logger.error("FATAL ERROR: Object %s has no sampling rate!!!"
                   % self.getName())
             sampling = -999.0
 
@@ -1454,7 +1456,7 @@ class SetOfPDBs(SetOfAtomStructs):
 
     def __init__(self):
         SetOfAtomStructs.__init__(self)
-        print("SetOfPDBs class has been renamed to SetOfAtomStructs. "
+        logger.warning("FOR DEVELOPERS: SetOfPDBs class has been renamed to SetOfAtomStructs. "
               "Please update your code.")
 
 
@@ -1631,6 +1633,12 @@ class SetOfCoordinates(EMSet):
             self._micrographsPointer.copy(micrographs)
         else:
             self._micrographsPointer.set(micrographs)
+
+        if not self._micrographsPointer.hasExtended():
+            logger.warning("FOR DEVELOPERS: Direct pointers to objects should be avoided. "
+                         "They are problematic in complex streaming scenarios. "
+                         "Pass a pointer to a protocol with extended "
+                         "(e.g.: input param are this kind of pointers. Without get()!)")
 
     def getFiles(self):
         filePaths = set()
@@ -1917,7 +1925,20 @@ class SetOfClasses(EMSet):
         return self._imagesPointer.get()
 
     def setImages(self, images):
-        self._imagesPointer.set(images)
+        """ Set the images (particles 2d associated with this set of classes.
+        Params:
+            images: An indirect pointer (with extended) to a set of images.
+        """
+        if images.isPointer():
+            self._imagesPointer.copy(images)
+        else:
+            self._imagesPointer.set(images)
+
+        if not self._imagesPointer.hasExtended():
+            logger.warning("FOR DEVELOPERS: Direct pointers to objects should be avoided. "
+                         "They are problematic in complex streaming scenarios. "
+                         "Pass a pointer to a protocol with extended "
+                         "(e.g.: input param are this kind of pointers. Without get()!)")
 
     def getDimensions(self):
         """Return first image dimensions as a tuple: (xdim, ydim, zdim)"""

--- a/pwem/protocols/protocol_extract_coordinates.py
+++ b/pwem/protocols/protocol_extract_coordinates.py
@@ -159,8 +159,8 @@ class ProtExtractCoords(ProtParticlePickingAuto):
         alignType = inPart.getAlignment()
 
         suffix = self.getSuffix(partsIds[0]) if partsIds is not None else ''
-        outputCoords = self._createSetOfCoordinates(inMics, suffix=suffix)
-
+        #outputCoords = self._createSetOfCoordinates(inMics, suffix=suffix)
+        outputCoords = self._createSetOfCoordinates(self.getInputMicrographsPointer(), suffix=suffix)
         # Prepare a double key dictionary to do the match: micname and micId
         micDict = dict()
         for mic in inMics.iterItems():
@@ -272,10 +272,7 @@ class ProtExtractCoords(ProtParticlePickingAuto):
             self._defineTransformRelation(self.getInputParticles(), outputSet)
             self._defineSourceRelation(self.getInputMicrographs(), outputSet)
 
-        # copyInfo raise an error since particles has no _boxsize
-        #   copyInfo does not do anything else
-        # outputSet.copyInfo(self.getInputParticles())
-        outputSet.setMicrographs(self.getInputMicrographs())
+        outputSet.setMicrographs(self.getInputMicrographsPointer())
 
         return outputSet
 

--- a/pwem/protocols/protocol_import/coordinates.py
+++ b/pwem/protocols/protocol_import/coordinates.py
@@ -108,16 +108,17 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
 
     # ------------------ STEPS functions --------------------------------------
     def createOutputStep(self, importFrom, *args):
-        inputMics = self.inputMicrographs.get()
+
         # scipion imports have a predefined format (see dataimport)
         if importFrom == self.IMPORT_FROM_SCIPION:
             from .dataimport import ScipionImport
             self.importFilePath = self.filesPath.get('').strip()
             sImport = ScipionImport(self, self.importFilePath)
             # this function defines outputs and relations
-            sImport.importCoordinates(inputMics)  
+            sImport.importCoordinates(self.inputMicrographs)
         else:
-            coordsSet = self._createSetOfCoordinates(inputMics)
+            # Pass the pointer with extended.
+            coordsSet = self._createSetOfCoordinates(self.inputMicrographs)
             coordsSet.setBoxSize(self.boxSize.get())
             ci = self.getImportClass()
             for coordFile, fileId in self.iterFiles():

--- a/pwem/protocols/protocol_particles.py
+++ b/pwem/protocols/protocol_particles.py
@@ -568,7 +568,7 @@ class ProtExtractParticles(ProtParticles):
             inputMics = self.getInputMicrographs()
             outputParts = self._createSetOfParticles()
             outputParts.copyInfo(inputMics)
-            outputParts.setCoordinates(self.getCoords())
+            outputParts.setCoordinates(self.inputCoordinates)
 
             if self.getAttributeValue('doFlip', False):
                 outputParts.setIsPhaseFlipped(not inputMics.isPhaseFlipped())

--- a/pwem/protocols/protocol_particles.py
+++ b/pwem/protocols/protocol_particles.py
@@ -104,6 +104,8 @@ class ProtExtractParticlesOutput(enum.Enum):
     """Predefined outputs for particle extraction protocols"""
     outputParticles = emobj.SetOfParticles
 
+
+# noinspection SqlDialectInspection
 class ProtExtractParticles(ProtParticles):
     """ Base class for all extract-particles protocols.
      This class will take care of the streaming functionality and
@@ -139,7 +141,7 @@ class ProtExtractParticles(ProtParticles):
                            'by micName or by micId. Difference in pixel size '
                            'will be handled automatically.')
 
-        form.addParam('inputMicrographs', params.PointerParam,
+        form.addParam('inputMicrographs', params.PointerParam, allowsNull=True,
                       pointerClass='SetOfMicrographs',
                       condition='downsampleType != %s' % SAME_AS_PICKING,
                       important=True, label='Input micrographs',

--- a/pwem/tests/workflows/test_workflow_mixed.py
+++ b/pwem/tests/workflows/test_workflow_mixed.py
@@ -21,6 +21,8 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+import  logging
+logger = logging.getLogger(__name__)
 
 import pyworkflow.tests as pwtests
 
@@ -54,7 +56,7 @@ class TestMixedBPV(TestWorkflow):
         #         self.validateFiles('protImport', protImport)
 
         # Import a set of volumes
-        print("Import Volume")
+        logger.info("Import Volume")
         protImportVol = self.newProtocol(emprot.ProtImportVolumes, filesPath=self.vol1,
                                          samplingRate=9.896)
         self.launchProtocol(protImportVol)
@@ -63,7 +65,7 @@ class TestMixedBPV(TestWorkflow):
         #        self.validateFiles('protImportVol', protImportVol)
 
         # Perform a downsampling on the micrographs
-        print("Downsampling...")
+        logger.info("Downsampling...")
         XmippProtPreprocessMicrographs = Domain.importFromPlugin('xmipp3.protocols',
                                                                  'XmippProtPreprocessMicrographs',
                                                                  doRaise=True)
@@ -77,7 +79,7 @@ class TestMixedBPV(TestWorkflow):
         #         self.validateFiles('protDownsampling', protDownsampling)
 
         # Estimate CTF on the downsampled micrographs
-        print("Performing CTFfind...")
+        logger.info("Performing CTFfind...")
         ProtCTFFind = Domain.importFromPlugin('cistem.protocols',
                                               'CistemProtCTFFind', doRaise=True)
         protCTF = self.newProtocol(ProtCTFFind, numberOfThreads=4,
@@ -96,7 +98,7 @@ class TestMixedBPV(TestWorkflow):
 
         #         self.validateFiles('protCTF', protCTF)
 
-        print("Running Eman import coordinates...")
+        logger.info("Running Eman import coordinates...")
         protPP = self.newProtocol(emprot.ProtImportCoordinates,
                                   importFrom=emprot.ProtImportCoordinates.IMPORT_FROM_EMAN,
                                   filesPath=self.crdsDir,
@@ -107,7 +109,7 @@ class TestMixedBPV(TestWorkflow):
                              "There was a problem with the Eman import coordinates")
 
         # Extract the SetOfParticles.
-        print("Run extract particles with other downsampling factor")
+        logger.info("Run extract particles with other downsampling factor")
         XmippProtExtractParticles = Domain.importFromPlugin(
             'xmipp3.protocols',
             'XmippProtExtractParticles')
@@ -147,7 +149,7 @@ class TestMixedBPV2(TestWorkflow):
         #         self.validateFiles('protImport', protImport)
 
         # Import a set of volumes
-        print("Import Volume")
+        logger.info("Import Volume")
         protImportVol = self.newProtocol(emprot.ProtImportVolumes, filesPath=self.vol1,
                                          samplingRate=9.896)
         self.launchProtocol(protImportVol)
@@ -156,7 +158,7 @@ class TestMixedBPV2(TestWorkflow):
         #        self.validateFiles('protImportVol', protImportVol)
 
         # Perform a downsampling on the micrographs
-        print("Downsampling...")
+        logger.info("Downsampling...")
         XmippProtPreprocessMicrographs = Domain.importFromPlugin(
             'xmipp3.protocols',
             'XmippProtPreprocessMicrographs',
@@ -171,7 +173,7 @@ class TestMixedBPV2(TestWorkflow):
         #         self.validateFiles('protDownsampling', protDownsampling)
 
         # Estimate CTF on the downsampled micrographs
-        print("Performing CTFfind...")
+        logger.info("Performing CTFfind...")
         ProtCTFFind = Domain.importFromPlugin('cistem.protocols',
                                               'CistemProtCTFFind', doRaise=True)
         protCTF = self.newProtocol(ProtCTFFind, numberOfThreads=4,
@@ -182,7 +184,7 @@ class TestMixedBPV2(TestWorkflow):
                              "There was a problem with the CTF estimation")
         #         self.validateFiles('protCTF', protCTF)
 
-        print("Running Eman import coordinates...")
+        logger.info("Running Eman import coordinates...")
         protPP = self.newProtocol(emprot.ProtImportCoordinates,
                                   importFrom=emprot.ProtImportCoordinates.IMPORT_FROM_EMAN,
                                   filesPath=self.crdsDir,
@@ -192,7 +194,7 @@ class TestMixedBPV2(TestWorkflow):
         self.assertIsNotNone(protPP.outputCoordinates,
                              "There was a problem with the Eman import coordinates")
 
-        print("<Run extract particles with Same as picking>")
+        logger.info("<Run extract particles with Same as picking>")
         XmippProtExtractParticles = Domain.importFromPlugin(
             'xmipp3.protocols',
             'XmippProtExtractParticles')
@@ -209,7 +211,7 @@ class TestMixedBPV2(TestWorkflow):
                              "There was a problem with the extract particles")
         # self.validateFiles('protExtract', protExtract)
 
-        print("Run Preprocess particles")
+        logger.info("Run Preprocess particles")
         XmippProtCropResizeParticles = Domain.importFromPlugin(
             'xmipp3.protocols',
             'XmippProtCropResizeParticles')
@@ -222,7 +224,7 @@ class TestMixedBPV2(TestWorkflow):
         self.assertIsNotNone(protCropResize.outputParticles,
                              "There was a problem with resize/crop the particles")
 
-        print("Run ML2D")
+        logger.info("Run ML2D")
         XmippProtML2D = Domain.importFromPlugin('xmipp3.protocols',
                                                 'XmippProtML2D')
         protML2D = self.newProtocol(XmippProtML2D, numberOfClasses=8, maxIters=2,
@@ -236,7 +238,7 @@ class TestMixedBPV2(TestWorkflow):
         #         #FIXME: Check the initial model with EMAn and restore the next step
         #         return
 
-        print("Run Initial Model")
+        logger.info("Run Initial Model")
 
         EmanProtInitModel = Domain.importFromPlugin('eman2.protocols',
                                                     'EmanProtInitModel',


### PR DESCRIPTION
  - Warning added in SetOfCoordinates.setMicrographs when not using an indirect pointer.
  - Warning added in SetOfClasses.setImages when not using an indirect pointer.
  - data.py test_workflow_mixed.py and uses logger instead of print
  - Import coordinates fixed for complex streaming cases.
  - Extract particles does not need SetOfMicrographs is "same as coordinates" is used.

CHANGES.txt updated