### PR TITLE
add import sequence from genbank

### DIFF
--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -145,7 +145,7 @@ class SequenceHandler:
                               'alphabet': alphabet, 'isAminoacids': isAmino})
         return sequences
 
-    def downloadSeqFromDatabase(self, seqID):
+    def downloadSeqFromDatabase(self, seqID, dataBase=None):
         # see http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html
         # for format/databases
         print("Connecting to database...")
@@ -155,19 +155,27 @@ class SequenceHandler:
         retries = 5
         record = None
         error = ""
+        if dataBase is None:
+            if self.isAminoacid:
+                dataBase = 'UnitProt'
+            else:
+                dataBase = 'GeneBank'
+
         while counter <= retries:  # retry up to 5 times if server busy
             try:
-                if self.isAminoacid:
-                    dataBase = 'UnitProt'
+                if dataBase == 'UnitProt':
                     url = "http://www.uniprot.org/uniprot/%s.xml"
                     format = "uniprot-xml"
                     handle = urlopen(url % seqID)
                     print("URL", url % seqID)
                 else:
-                    dataBase = 'GeneBank'
-                    Entrez.email = "adam.richards@stat.duke.edu"
+                    if self.isAminoacid:
+                        db = "protein"
+                    else:
+                        db = "nucleotide"
+                    Entrez.email = "scipion@cnb.csic.es"
                     format = "fasta"
-                    handle = Entrez.efetch(db="nucleotide", id=seqID,
+                    handle = Entrez.efetch(db=db, id=seqID,
                                            rettype=format, retmode="text")
 
                 record = SeqIO.read(handle, format)

--- a/pwem/protocols/protocol_import/sequence.py
+++ b/pwem/protocols/protocol_import/sequence.py
@@ -42,14 +42,17 @@ class ProtImportSequence(ProtImportFiles):
     project"""
     _label = 'import sequence'
     # SEQUENCEFILENAME = '_sequence.fasta'
+    # proteins
     IMPORT_FROM_PLAIN_TEXT = 0
     IMPORT_FROM_STRUCTURE = 1
     IMPORT_FROM_FILES = 2
     IMPORT_FROM_UNIPROT = 3
+    IMPORT_FROM_PROTEIN_GENEBANK = 4
+    # nucleotics
     IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT = 0
     IMPORT_FROM_NUCLEOTIDE_STRUCTURE = 1
     IMPORT_FROM_NUCLEOTIDE_FILES = 2
-    IMPORT_FROM_GENEBANK = 3
+    IMPORT_FROM_NUCLEOTIDE_GENEBANK = 3
     IMPORT_STRUCTURE_FROM_ID = 0
     IMPORT_STRUCTURE_FROM_FILES = 1
 
@@ -98,7 +101,7 @@ class ProtImportSequence(ProtImportFiles):
                       help='Select the type of sequence to import.')
         form.addParam('inputProteinSequence', params.EnumParam,
                       choices=['plain text', 'atomic structure', 'file',
-                               'UniProt ID'],
+                               'UniProt ID', 'NCBI/GENBANK ID'],
                       display=params.EnumParam.DISPLAY_HLIST,
                       condition='inputSequence == %d' % emconv.SEQ_TYPE_AMINOACIDS,
                       label="From ",
@@ -137,6 +140,7 @@ class ProtImportSequence(ProtImportFiles):
                            'Pyrrolysine\nThis alphabet is not intended to be '
                            'used with X for Selenocysteine (an ad-hoc standard'
                            ' prior to the IUPAC adoption of U instead).\n')
+
         form.addParam('uniProtSequence', params.StringParam,
                       condition='inputSequence == %d and '
                                 'inputProteinSequence == %d' %
@@ -247,12 +251,17 @@ class ProtImportSequence(ProtImportFiles):
                            'file.\nIf your file contains more than one '
                            'sequence, only the first one will be considered.')
         form.addParam('geneBankSequence', params.StringParam,
-                      condition='inputSequence == %d and '
-                                'inputNucleotideSequence == %d' %
+                      condition='(inputSequence == %d and '
+                                'inputNucleotideSequence == %d) or '
+                                '(inputSequence == %d and '
+                                'inputProteinSequence == %d)' %
                                 (emconv.SEQ_TYPE_NUCLEOTIDES,
-                                 self.IMPORT_FROM_GENEBANK),
+                                 self.IMPORT_FROM_NUCLEOTIDE_GENEBANK,
+                                 emconv.SEQ_TYPE_AMINOACIDS,
+                                 self.IMPORT_FROM_PROTEIN_GENEBANK),
                       label="GeneBank accession ", allowsNull=True,
                       help='Write a GeneBank accession.\n')
+
 
     def _insertAllSteps(self):
         self.name = self.inputSequenceName.get()
@@ -268,6 +277,10 @@ class ProtImportSequence(ProtImportFiles):
                 sequenceDB = self._getUniProtID()
                 self._insertFunctionStep('sequenceDatabaseDownloadStep',
                                          sequenceDB)
+            elif self.inputProteinSequence == self.IMPORT_FROM_PROTEIN_GENEBANK:
+                sequenceDB = self._getGeneBankID()
+                self._insertFunctionStep('sequenceDatabaseDownloadStep',
+                                         sequenceDB)
             elif self.inputProteinSequence == self.IMPORT_FROM_FILES:
                 self.sequenceFile = self.fileSequence.get()
                 sequenceFile = self.sequenceFile
@@ -281,7 +294,7 @@ class ProtImportSequence(ProtImportFiles):
                     self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE:
                 chainId = self.inputStructureChain.get()
                 self._insertFunctionStep('getSequenceOfChainStep', chainId)
-            elif self.inputNucleotideSequence == self.IMPORT_FROM_GENEBANK:
+            elif self.inputNucleotideSequence == self.IMPORT_FROM_NUCLEOTIDE_GENEBANK:
                 sequenceDB = self._getGeneBankID()
                 self._insertFunctionStep('sequenceDatabaseDownloadStep',
                                          sequenceDB)
@@ -351,13 +364,15 @@ class ProtImportSequence(ProtImportFiles):
         """Download UniProt/GeneBank sequence from its respective database
         """
         # sequenceDB = str(sequenceDB)
+        isAminoacid=(self.inputSequence == emconv.SEQ_TYPE_AMINOACIDS)
         if self.uniProtSequence.get() is not None:
-            seqHandler = emconv.SequenceHandler()
+            seqHandler = emconv.SequenceHandler(isAminoacid=isAminoacid)
+            dataBase = 'UnitProt'
 
         elif self._getGeneBankID() is not None:
-            seqHandler = emconv.SequenceHandler(isAminoacid=False)
-
-        seqDic, error = seqHandler.downloadSeqFromDatabase(sequenceDB)
+            seqHandler = emconv.SequenceHandler(isAminoacid=isAminoacid)
+            dataBase = 'GeneBank'
+        seqDic, error = seqHandler.downloadSeqFromDatabase(seqID = sequenceDB, dataBase=dataBase)
         if seqDic is None:
             print("Error: ", error)
             self.setAborted()
@@ -459,7 +474,7 @@ class ProtImportSequence(ProtImportFiles):
                         self.IMPORT_STRUCTURE_FROM_FILES:
                     summary.append("Sequence *%s* imported from file *%s*\n"
                                    % (self.name, self.pdbFile.get()))
-            elif self.inputNucleotideSequence == self.IMPORT_FROM_GENEBANK:
+            elif self.inputNucleotideSequence == self.IMPORT_FROM_NUCLEOTIDE_GENEBANK:
                 summary.append("Sequence *%s* imported from geneBank ID "
                                "*%s*\n"
                                % (self.name, geneBankID))

--- a/pwem/tests/protocols/test_protocols_import_sequence.py
+++ b/pwem/tests/protocols/test_protocols_import_sequence.py
@@ -52,6 +52,7 @@ class TestImportSequence(TestImportBase):
     pdbID2 = "205d"  # RNA
     pdbID3 = "1aoi"  # DNA and protein
     GENEBANKID = 'AJ520101.1'
+    GENEBANKIDPROT = 'CAE8970392.1'
     UNIPROTID = 'P12345'
 
     def testImportUserNucleotideSequence1(self):
@@ -329,7 +330,7 @@ class TestImportSequence(TestImportBase):
         args = {'inputSequenceName': self.NAME,
                 'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
                 'inputNucleotideSequence':
-                    emprot.ProtImportSequence.IMPORT_FROM_GENEBANK,
+                    emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_GENEBANK,
                 'geneBankSequence': self.GENEBANKID
                 }
         prot11 = self.newProtocol(emprot.ProtImportSequence, **args)
@@ -352,25 +353,22 @@ class TestImportSequence(TestImportBase):
         """
         Import a single nucleotide sequence from GeneBank
         """
-        args = {'inputSequenceID': self.USERID,
-                'inputSequenceName': self.NAME,
-                'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
-                'inputNucleotideSequence':
-                    emprot.ProtImportSequence.IMPORT_FROM_GENEBANK,
-                'geneBankSequence': self.GENEBANKID
+        args = {'inputSequenceName': self.NAME,
+                'inputProteinSequence':
+                    emprot.ProtImportSequence.IMPORT_FROM_PROTEIN_GENEBANK,
+                'geneBankSequence': self.GENEBANKIDPROT
                 }
         prot12 = self.newProtocol(emprot.ProtImportSequence, **args)
-        prot12.setObjLabel('12_import nucleotide,\nseq from '
+        prot12.setObjLabel('12.5_import protein,\nseq from '
                            'GeneBank')
         self.launchProtocol(prot12)
         sequence = prot12.outputSequence
-        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual(self.GENEBANKIDPROT, sequence.getId())
         self.assertEqual('USER_SEQ', sequence.getSeqName())
-        self.assertEqual("User description",
+        self.assertEqual('CAE8970392.1 unnamed protein product, partial [Tetraselmis striata]',
                          sequence.getDescription())
-        self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
+        self.assertEqual("MPDHHLRYFR", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
                          emconv.indexToAlphabet(sequence.getIsAminoacids(),
                                                 sequence.getAlphabet()).letters)
 


### PR DESCRIPTION
Add to "import sequence" the databank genbank (ncbi) as source of sequences. Scipion can access uniprot but uniprot does not has sequence from "uncharacterized protein" that is organism that are scarcelly known.


added test 
./scipion3 test  pwem.tests.protocols.test_protocols_import_sequence.TestImportSequence.testImportGeneBankNucleotideSequence