### PR TITLE
add SetOfAtomStructs to DataViewer targets

### DIFF
--- a/pwem/viewers/viewers_data.py
+++ b/pwem/viewers/viewers_data.py
@@ -57,6 +57,7 @@ class DataViewer(pwviewer.Viewer):
         emobj.SetOfNormalModes,
         emobj.SetOfPrincipalComponents,
         emobj.SetOfPDBs,
+        emobj.SetOfAtomStructs,
         emprot.ProtParticlePicking,
         emprot.ProtImportMovies,
         # TiltPairs related data


### PR DESCRIPTION
SetOfPdbs was there but SetOfAtomStructs wasn't. Now that it's added, we can use this viewer for them.