### PR TITLE
alphabet is not longer supported by biopython

### DIFF
--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -53,6 +53,10 @@ import numpy
 import pyworkflow.utils as pwutils
 import shutil
 
+from pwem.objects.data import Alphabet
+
+
+
 SECTION = '_scipion_attributes'
 NAME, RECIP, SPEC, VALUE = SECTION + '.name', SECTION + '.recipient', SECTION + '.specifier', SECTION + '.value'
 
@@ -322,7 +326,7 @@ class AtomicStructHandler:
 
         return listOfChains, listOfResidues
 
-    def getSequenceFromChain(self, modelID, chainID):
+    def getSequenceFromChain(self, modelID, chainID, returnAlphabet=False):
         self.checkRead()
         seq = list()
         for model in self.structure:
@@ -332,7 +336,7 @@ class AtomicStructHandler:
                         if len(chain.get_unpacked_list()[0].resname) == 1:
                             print("Your sequence is a nucleotide sequence ("
                                   "RNA)\n")
-                            # alphabet = IUPAC.IUPACAmbiguousRNA._upper()
+                            alphabet = Alphabet.UNAMBIGOUS_RNA_ALPHABET
                             for residue in chain:
                                 # Check if the residue belongs to the
                                 # standard RNA and add those residues to the
@@ -345,7 +349,7 @@ class AtomicStructHandler:
                         elif len(chain.get_unpacked_list()[0].resname) == 2:
                             print("Your sequence is a nucleotide sequence ("
                                   "DNA)\n")
-                            # alphabet = IUPAC.ExtendedIUPACDNA._upper()
+                            alphabet = Alphabet.UNAMBIGOUS_DNA_ALPHABET
                             for residue in chain:
                                 # Check if the residue belongs to the
                                 # standard DNA and add those residues to the
@@ -359,7 +363,7 @@ class AtomicStructHandler:
                             counter = 0
                             for residue in chain:
                                 if is_aa(residue.get_resname(), standard=True):
-                                    # alphabet = IUPAC.ExtendedIUPACProtein._upper()
+                                    alphabet = Alphabet.EXTENDED_PROTEIN_ALPHABET
                                     # The test checks if the amino acid
                                     # is one of the 20 standard amino acids
                                     # Some proteins have "UNK" or "XXX", or other symbols
@@ -379,7 +383,10 @@ class AtomicStructHandler:
                         while seq[0] == "X":
                             del seq[0]
                         # return Seq(str(''.join(seq)), alphabet=alphabet)
-                        return Seq(str(''.join(seq)))
+                        if returnAlphabet:
+                            return Seq(str(''.join(seq))), alphabet
+                        else:
+                            return Seq(str(''.join(seq)))
 
     def getFullID(self, model_id='0', chain_id=None):
         """

--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -31,45 +31,32 @@ from os.path import exists
 
 
 # sequence related stuff
-SEQ_TYPE = ['aminoacids', 'nucleotides']
-SEQ_TYPE_AMINOACIDS = 0
-SEQ_TYPE_NUCLEOTIDES = 1
-IUPAC_PROTEIN_ALPHABET = ['Extended Protein', 'Protein']
-EXTENDED_PROTEIN_ALPHABET = 0
-PROTEIN_ALPHABET = 1
-IUPAC_NUCLEOTIDE_ALPHABET = ['Ambiguous DNA', 'Unambiguous DNA',
-                             'Extended DNA', 'Ambiguous RNA',
-                             'Unambiguous RNA']
-EXTENDED_DNA_ALPHABET = 0
-AMBIGOUS_DNA_ALPHABET = 1
-UNAMBIGOUS_DNA_ALPHABET = 2
-AMBIGOUS_RNA_ALPHABET = 3
-UNAMBIGOUS_RNA_ALPHABET = 4
 
 
 from Bio.Seq import Seq
-from Bio.Alphabet import IUPAC
 from Bio import Entrez, SeqIO
 import sys
 from Bio.SeqRecord import SeqRecord
 from Bio.Align.Applications import ClustalOmegaCommandline, MuscleCommandline
 from Bio import pairwise2
 from pyworkflow.utils import getExt
+from pwem.objects.data import Alphabet
+
 
 class SequenceHandler:
     def __init__(self, sequence=None,
-                 iUPACAlphabet=0,
-                 isAminoacid=True):
+                 iUPACAlphabet=Alphabet.DUMMY_ALPHABET):
+        if iUPACAlphabet == Alphabet.DUMMY_ALPHABET:
+            self.isAminoacid = None
+        else:      
+            self.isAminoacid =  (iUPACAlphabet <   Alphabet.AMBIGOUS_DNA_ALPHABET)
 
-        self.isAminoacid = isAminoacid
-        self.alphabet = indexToAlphabet(isAminoacid, iUPACAlphabet)
+        self.alphabet = iUPACAlphabet ##  indexToAlphabet(isAminoacid, iUPACAlphabet)
 
         if sequence is not None:
-            # sequence = cleanSequence(self.alphabet, sequence)
-            self._sequence = Seq(sequence, alphabet=self.alphabet)
+            self._sequence = cleanSequence(self.alphabet, sequence)
         else:
             self._sequence = None
-            # type(self._sequence):  <class 'Bio.Seq.Seq'>
 
     def getTypeFromFile(self, fileName):
         '''Returns the expected BioPython file type according to the filename'''
@@ -95,7 +82,7 @@ class SequenceHandler:
             records = list(SeqIO.parse(fileName, type))
         else:
             records = []
-        records.append(SeqRecord(self._sequence, id=seqID, name=name,
+        records.append(SeqRecord(Seq(self._sequence), id=seqID, name=name,
                                  description=seqDescription))
         with open(fileName, "w") as output_handle:
             SeqIO.write(records, output_handle, type)
@@ -116,7 +103,7 @@ class SequenceHandler:
 
         records = []
         for seq, seqID, name, seqDescription in zip(sequences, seqIDs, names, seqDescriptions):
-            records.append(SeqRecord(seq, id=seqID, name=name,
+            records.append(SeqRecord(Seq(seq), id=seqID, name=name,
                                description=seqDescription))
         # type(record): < class 'Bio.SeqRecord.SeqRecord'>
         with open(fileName, "w") as output_handle:
@@ -125,6 +112,7 @@ class SequenceHandler:
     def readSequenceFromFile(self, fileName, type="fasta", isAmino=True):
         '''From a sequences file, returns a dictionary with ther FIRST sequence info.
         Dictionary: {'seqID': seqID1, 'sequence': sequence1, 'description': description1, 'alphabet': alphabet1}'''
+
         if type is None:
             type = self.getTypeFromFile(fileName)
         return self.readSequencesFromFile(fileName, isAmino=isAmino)[0]
@@ -133,22 +121,35 @@ class SequenceHandler:
         '''From a sequences file, returns a list of dictionaries with each sequence info.
         Dictionary: [{'seqID': seqID1, 'sequence': sequence1, 'description': description1, 'alphabet': alphabet1},
                      ...]'''
+
         if type is None:
             type = self.getTypeFromFile(fileName)
 
         sequences = []
+
         records = SeqIO.parse(fileName, type)
+
         for rec in records:
-            alphabet = alphabetToIndex(isAmino, rec.seq.alphabet)
-            sequences.append({'seqID': rec.id, 'sequence': str(rec.seq),
+            sequence = str(rec.seq)
+
+            if isAmino:
+                self.alphabet = Alphabet.EXTENDED_PROTEIN_ALPHABET
+            elif 'U' in sequence:
+                self.alphabet = Alphabet.UNAMBIGOUS_RNA_ALPHABET
+            elif 'T' in sequence:
+                self.alphabet = Alphabet.UNAMBIGOUS_DNA_ALPHABET
+            else:
+                self.alphabet = Alphabet.NUCLEOTIDES_ALPHABET
+
+            sequences.append({'seqID': rec.id, 'sequence': sequence,
                               'name': rec.name, 'description': rec.description,
-                              'alphabet': alphabet, 'isAminoacids': isAmino})
+                              'isAminoacids': isAmino, 'alphabet': self.alphabet})
         return sequences
 
     def downloadSeqFromDatabase(self, seqID, dataBase=None):
         # see http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html
         # for format/databases
-        print("Connecting to database...")
+
         seqID = str(seqID)
         sys.stdout.flush()
         counter = 1
@@ -166,13 +167,16 @@ class SequenceHandler:
                 if dataBase == 'UnitProt':
                     url = "http://www.uniprot.org/uniprot/%s.xml"
                     format = "uniprot-xml"
+
                     handle = urlopen(url % seqID)
-                    print("URL", url % seqID)
+                    alphabet = Alphabet.EXTENDED_PROTEIN_ALPHABET
                 else:
                     if self.isAminoacid:
                         db = "protein"
+                        alphabet = Alphabet.EXTENDED_PROTEIN_ALPHABET
                     else:
                         db = "nucleotide"
+                        alphabet = Alphabet.NUCLEOTIDES_ALPHABET
                     Entrez.email = "scipion@cnb.csic.es"
                     format = "fasta"
                     handle = Entrez.efetch(db=db, id=seqID,
@@ -197,7 +201,7 @@ class SequenceHandler:
         seqDic = None
         if record is not None:
             seqDic = {'seqID': record.id, 'sequence': str(record.seq), 'description': record.description,
-                      'alphabet': record.seq.alphabet}
+                      'alphabet': alphabet}
         return seqDic, error
 
     def alignSeq(self, referenceSeq):
@@ -216,55 +220,22 @@ def sequenceLength(filename, format='fasta'):
 
 
 def cleanSequenceScipion(isAminoacid, iUPACAlphabet, sequence):
-    return cleanSequence(indexToAlphabet(isAminoacid, iUPACAlphabet), sequence)
+    return cleanSequence(iUPACAlphabet, sequence)
 
 
 def cleanSequence(alphabet, sequence):
+    """Remove all characters that are not in the alphabet
+       :param alphabet: the alphabet to use as integer
+       :param sequence: the sequence to clean
+       """
     str_list = []
     for item in sequence.upper():
-        if item in alphabet.letters:
+        if item in Alphabet.alphabets[alphabet]:
             str_list.append(item)
     value = ''.join(str_list)
     return ''.join(str_list)
 
 
-def indexToAlphabet(isAminoacid, iUPACAlphabet):
-    if isAminoacid:
-        if iUPACAlphabet == EXTENDED_PROTEIN_ALPHABET:
-            alphabet = IUPAC.ExtendedIUPACProtein
-        else:
-            alphabet = IUPAC.IUPACProtein
-    else:
-        if iUPACAlphabet == EXTENDED_DNA_ALPHABET:
-            alphabet = IUPAC.ExtendedIUPACDNA
-        elif iUPACAlphabet == AMBIGOUS_DNA_ALPHABET:
-            alphabet = IUPAC.IUPACAmbiguousDNA
-        elif iUPACAlphabet == UNAMBIGOUS_DNA_ALPHABET:
-            alphabet = IUPAC.IUPACUnambiguousDNA
-        elif iUPACAlphabet == AMBIGOUS_RNA_ALPHABET:
-            alphabet = IUPAC.IUPACAmbiguousRNA
-        else:
-            alphabet = IUPAC.IUPACUnambiguousRNA
-    return alphabet
-
-
-def alphabetToIndex(isAminoacid, alphabet):
-    if isAminoacid:
-        if isinstance(alphabet, IUPAC.ExtendedIUPACProtein):
-            return EXTENDED_PROTEIN_ALPHABET
-        else:
-            return PROTEIN_ALPHABET
-    else:
-        if isinstance(alphabet, IUPAC.ExtendedIUPACDNA):
-            return EXTENDED_DNA_ALPHABET
-        elif isinstance(alphabet, IUPAC.IUPACAmbiguousDNA):
-            return AMBIGOUS_DNA_ALPHABET
-        elif isinstance(alphabet, IUPAC.IUPACUnambiguousDNA):
-            return UNAMBIGOUS_DNA_ALPHABET
-        elif isinstance(alphabet, IUPAC.IUPACAmbiguousRNA):
-            return AMBIGOUS_RNA_ALPHABET
-        else:
-            return UNAMBIGOUS_RNA_ALPHABET
 
 
 def saveFileSequencesToAlign(SeqDic, inFile, type="fasta"):

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -780,12 +780,64 @@ class EMFile(EMObject):
         """ Use the _objValue attribute to store filename. """
         self._filename.set(filename)
 
+class Alphabet():
+    """ class with a dictionary of all valid alphabets"""
+    # sequence types
+    AMINOACIDS = 0
+    NUCLEOTIDES = 1
+    
+    SEQ_TYPE = ['aminoacids', 'nucleotides']
+
+    # alphabets for proteins
+    PROTEIN_ALPHABET = 0
+    EXTENDED_PROTEIN_ALPHABET = 1
+
+    # alphabets for nucleotides
+    AMBIGOUS_DNA_ALPHABET = 2
+    UNAMBIGOUS_DNA_ALPHABET = 3
+    EXTENDED_DNA_ALPHABET = 4
+    AMBIGOUS_RNA_ALPHABET = 5
+    UNAMBIGOUS_RNA_ALPHABET = 6 
+    NUCLEOTIDES_ALPHABET = 7
+
+    # dummy alphabet
+    DUMMY_ALPHABET = 8
+
+    # dictionary with all alphabets
+    alphabets = {}; alphabetsLabels = {}
+
+    alphabets[PROTEIN_ALPHABET] = 'ACDEFGHIKLMNPQRSTVWY'
+    alphabets[EXTENDED_PROTEIN_ALPHABET] = 'ACDEFGHIKLMNPQRSTVWYBJOUXZ'
+    alphabets[AMBIGOUS_DNA_ALPHABET] = 'GATCRYWSMKHBVDN'
+    alphabets[UNAMBIGOUS_DNA_ALPHABET] = 'GATC'
+    alphabets[EXTENDED_DNA_ALPHABET] = 'GATCBDSW'
+    alphabets[AMBIGOUS_RNA_ALPHABET] = 'GAUCRYWSMKHBVDN'
+    alphabets[UNAMBIGOUS_RNA_ALPHABET] = 'GAUC'
+    alphabets[NUCLEOTIDES_ALPHABET] = 'GAC'
+    alphabets[DUMMY_ALPHABET] = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+    # dictionary with all alphabets labels
+    alphabetsLabels[PROTEIN_ALPHABET] = 'Protein'
+    alphabetsLabels[EXTENDED_PROTEIN_ALPHABET] = 'Extended Protein'
+    alphabetsLabels[AMBIGOUS_DNA_ALPHABET] = 'Ambigous DNA'
+    alphabetsLabels[UNAMBIGOUS_DNA_ALPHABET] = 'Unambigous DNA'
+    alphabetsLabels[EXTENDED_DNA_ALPHABET] = 'Extended DNA'
+    alphabetsLabels[AMBIGOUS_RNA_ALPHABET] = 'Ambigous RNA'
+    alphabetsLabels[UNAMBIGOUS_RNA_ALPHABET] = 'Unambigous RNA'
+
+    
 
 class Sequence(EMObject):
     """Class containing a sequence of aminoacids/nucleotides
        Attribute names follow the biopython default ones
+            param: name: name of the sequence
+            param: sequence: string with the sequence
+            param: alphabet: integer with the alphabet to be used
+            param: isAminoacids: boolean indicating if the sequence is an aminoacid sequence
+            param: id: string with the sequence id
+            param: description: string with the sequence description
+           
     """
-
     def __init__(self, name=None, sequence=None,
                  alphabet=None, isAminoacids=True, id=None, description=None,
                  **kwargs):
@@ -853,7 +905,7 @@ class Sequence(EMObject):
         '''Exports the sequence to the specified file'''
         import pwem.convert as emconv
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            isAminoacid=self.getIsAminoacids())
+                                            self._alphabet.get())
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'
@@ -861,13 +913,17 @@ class Sequence(EMObject):
         seqHandler.saveFile(seqFileName, seqID,
                             name=seqName, seqDescription=seqDescription,
                             type=None)
+                            #seqFiP12345 USER_SEQ 
+                            # Aspartate aminotransferase, mitochondrial
 
     def appendToFile(self, seqFileName):
         '''Exports the sequence to the specified file. If it already exists,
         the sequence is appended to the ones in the file'''
+        print("Appending sequence to file: %s" % seqFileName)
         import pwem.convert as emconv
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            isAminoacid=self.getIsAminoacids())
+                                            Alphabet.DUMMY_ALPHABET)
+        print("after seqHandler")
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'

--- a/pwem/protocols/protocol_import/sequence.py
+++ b/pwem/protocols/protocol_import/sequence.py
@@ -35,7 +35,7 @@ import pwem.convert as emconv
 from pwem.convert import AtomicStructHandler
 
 from .base import ProtImportFiles
-
+from time import sleep
 
 class ProtImportSequence(ProtImportFiles):
     """ Protocol to import an aminoacid/nucleotide sequence file to the
@@ -343,6 +343,8 @@ class ProtImportSequence(ProtImportFiles):
             if not exists(tmpFilePath):
                 # wizard has not used and the file has not been downloaded yet
                 self.structureHandler.readFromPDBDatabase(pdbID, dir="/tmp")
+                # wait for the file to be fully downloaded and written
+                sleep(2)
             self.structureHandler.read(tmpFilePath)
         else:
             # PDB from file

--- a/pwem/tests/data/test_data.py
+++ b/pwem/tests/data/test_data.py
@@ -20,6 +20,7 @@ from pwem.emlib import metadata as md
 import pwem.protocols as emprot
 import pyworkflow.tests as pwtests
 from pwem.convert import SequenceHandler
+from pwem.objects.data import Alphabet
 
 # set to true if you want to check how fast is the access to
 # the database

--- a/pwem/tests/protocols/test_protocols_import_sequence.py
+++ b/pwem/tests/protocols/test_protocols_import_sequence.py
@@ -30,7 +30,7 @@ import pyworkflow.tests as pwtests
 
 import pwem.protocols as emprot
 import pwem.convert as emconv
-
+from pwem.objects.data import Alphabet
 
 class TestImportBase(pwtests.BaseTest):
     @classmethod
@@ -62,8 +62,8 @@ class TestImportSequence(TestImportBase):
         """
         args = {'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
-                'nucleotideIUPACalphabet': emconv.EXTENDED_DNA_ALPHABET,
+                'inputSequence': Alphabet.NUCLEOTIDES,
+                'nucleotideIUPACalphabet': Alphabet.EXTENDED_DNA_ALPHABET,
                 'inputRawSequence': self.NUCLEOTIDESEQ1
                 }
         prot1 = self.newProtocol(emprot.ProtImportSequence, **args)
@@ -76,9 +76,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("AATGCGGTTG", sequence.getSequence()[:10])
-        self.assertEqual("GATCBDSW",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_DNA_ALPHABET, sequence.getAlphabet())
 
     def testImportUserNucleotideSequence2(self):
         """
@@ -87,8 +85,8 @@ class TestImportSequence(TestImportBase):
         """
         args = {'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
-                'nucleotideIUPACalphabet': emconv.AMBIGOUS_RNA_ALPHABET,
+                'inputSequence': Alphabet.NUCLEOTIDES,
+                'nucleotideIUPACalphabet': Alphabet.AMBIGOUS_RNA_ALPHABET,
                 'inputRawSequence': self.NUCLEOTIDESEQ1
                 }
         prot2 = self.newProtocol(emprot.ProtImportSequence, **args)
@@ -101,9 +99,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("AAGCGGGGGB", sequence.getSequence()[:10])
-        self.assertEqual("GAUCRYWSMKHBVDN",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.AMBIGOUS_RNA_ALPHABET, sequence.getAlphabet())
 
     def testImportStructureNucleotideSequence1(self):
         """
@@ -111,7 +107,7 @@ class TestImportSequence(TestImportBase):
         """
         args = {'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
                 'inputStructureSequence':
@@ -129,9 +125,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("GGACUUUGGU", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_RNA_ALPHABET, sequence.getAlphabet()) # RNA
 
     def testImportStructureNucleotideSequence2(self):
         """
@@ -140,7 +134,7 @@ class TestImportSequence(TestImportBase):
         args = {'inputSequenceID': self.USERID,
                 'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
                 'inputStructureSequence':
@@ -158,9 +152,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("GGACUUUGGU", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_RNA_ALPHABET, sequence.getAlphabet()) # RNA
 
     def testImportStructureNucleotideSequence3(self):
         """
@@ -168,7 +160,7 @@ class TestImportSequence(TestImportBase):
         """
         args = {'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
                 'inputStructureSequence':
@@ -186,9 +178,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("ATCAATATCC", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportStructureNucleotideSequence4(self):
         """
@@ -197,7 +187,7 @@ class TestImportSequence(TestImportBase):
         args = {'inputSequenceID': self.USERID,
                 'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
                 'inputStructureSequence':
@@ -215,16 +205,14 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("ATCAATATCC", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportFileNucleotideSequence1(self):
         """
         Import a single nucleotide sequence from a text file
         """
         args = {'inputSequenceName': self.NAME,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
                 'fileSequence': self.dsModBuild.getFile(
@@ -242,9 +230,7 @@ class TestImportSequence(TestImportBase):
                          "and nifB gene",
                          sequence.getDescription())
         self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportFileNucleotideSequence2(self):
         """
@@ -253,7 +239,7 @@ class TestImportSequence(TestImportBase):
         args = {'inputSequenceID': self.USERID,
                 'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
                 'fileSequence': self.dsModBuild.getFile(
@@ -268,16 +254,14 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportFileNucleotideSequence3(self):
         """
         Import a single nucleotide sequence from a text file
         """
         args = {'inputSequenceName': self.NAME,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
                 'fileSequence': self.dsModBuild.getFile(
@@ -292,9 +276,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("Seq1 This is the sequence number one",
                          sequence.getDescription())
         self.assertEqual("TGGCTAAATA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportFileNucleotideSequence4(self):
         """
@@ -304,7 +286,7 @@ class TestImportSequence(TestImportBase):
         args = {'inputSequenceID': self.USERID,
                 'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
                 'fileSequence': self.dsModBuild.getFile(
@@ -319,16 +301,14 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("User description",
                          sequence.getDescription())
         self.assertEqual("TGGCTAAATA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.UNAMBIGOUS_DNA_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportGeneBankNucleotideSequence1(self):
         """
         Import a single nucleotide sequence from GeneBank
         """
         args = {'inputSequenceName': self.NAME,
-                'inputSequence': emconv.SEQ_TYPE_NUCLEOTIDES,
+                'inputSequence': Alphabet.NUCLEOTIDES,
                 'inputNucleotideSequence':
                     emprot.ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_GENEBANK,
                 'geneBankSequence': self.GENEBANKID
@@ -345,9 +325,7 @@ class TestImportSequence(TestImportBase):
                          "and nifB gene",
                          sequence.getDescription())
         self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
-        self.assertEqual("GAUC",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.NUCLEOTIDES_ALPHABET, sequence.getAlphabet()) # DNA
 
     def testImportGeneBankNucleotideSequence2(self):
         """
@@ -368,9 +346,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual('CAE8970392.1 unnamed protein product, partial [Tetraselmis striata]',
                          sequence.getDescription())
         self.assertEqual("MPDHHLRYFR", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportUserAminoacidSequence1(self):
         """
@@ -391,10 +367,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("USER_SEQ", sequence.getSeqName())
         self.assertEqual("User description", sequence.getDescription())
         self.assertEqual("LARKJLAKPA", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWYBXZJUO",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters
-                         )
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Extended protein
 
     def testImportUserAminoacidSequence2(self):
         """
@@ -403,7 +376,7 @@ class TestImportSequence(TestImportBase):
         """
         args = {'inputSequenceName': self.NAME,
                 'inputSequenceDescription': self.DESCRIPTION,
-                'proteinIUPACalphabet': emconv.PROTEIN_ALPHABET,
+                'proteinIUPACalphabet': Alphabet.AMINOACIDS,
                 'inputRawSequence': self.AMINOACIDSSEQ1
                 }
         prot14 = self.newProtocol(emprot.ProtImportSequence, **args)
@@ -415,10 +388,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("USER_SEQ", sequence.getSeqName())
         self.assertEqual("User description", sequence.getDescription())
         self.assertEqual("LARKLAKPAV", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters
-                         )
+        self.assertEqual(Alphabet.PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportStructureAminoacidSequence1(self):
         """
@@ -443,9 +413,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("USER_SEQ", sequence.getSeqName())
         self.assertEqual("User description", sequence.getDescription())
         self.assertEqual("VHLSGEEKSA", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportStructureAminoacidSequence2(self):
         """
@@ -470,9 +438,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual("USER_SEQ", sequence.getSeqName())
         self.assertEqual("User description", sequence.getDescription())
         self.assertEqual("VHLSGEEKSA", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportFileAminoacidSequence1(self):
         """
@@ -495,9 +461,7 @@ class TestImportSequence(TestImportBase):
                          'subunit I (mitochondrion) [Homo sapiens]',
                          sequence.getDescription())
         self.assertEqual("MFADRWLFST", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportFileAminoacidSequence2(self):
         """
@@ -520,9 +484,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual('User description',
                          sequence.getDescription())
         self.assertEqual("MFADRWLFST", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportUniprotAminoacidSequence1(self):
         """
@@ -543,9 +505,7 @@ class TestImportSequence(TestImportBase):
         self.assertEqual('Aspartate aminotransferase, mitochondrial',
                          sequence.getDescription())
         self.assertEqual("MALLHSARVL", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein
 
     def testImportUniprotAminoacidSequence2(self):
         """
@@ -568,6 +528,4 @@ class TestImportSequence(TestImportBase):
         self.assertEqual('User description',
                          sequence.getDescription())
         self.assertEqual("MALLHSARVL", sequence.getSequence()[:10])
-        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
-                         emconv.indexToAlphabet(sequence.getIsAminoacids(),
-                                                sequence.getAlphabet()).letters)
+        self.assertEqual(Alphabet.EXTENDED_PROTEIN_ALPHABET, sequence.getAlphabet()) # Protein

--- a/pwem/viewers/viewer_sequence.py
+++ b/pwem/viewers/viewer_sequence.py
@@ -55,8 +55,7 @@ class SequenceViewer(pwviewer.Viewer):
         # object (obj.getSequence()) in a Biopython Sequence:
         # Let keep the SequenceHandler import here to avoid a default BioPython
         # import
-        seqHandler = emconv.SequenceHandler(obj.getSequence(),
-                                            isAminoacid=obj.getIsAminoacids())
+        seqHandler = emconv.SequenceHandler(obj.getSequence())
         seqBio = seqHandler._sequence  # Bio.Seq.Seq object
         # Step 2: retrieving of the other args needed in the saveFile method
         seqID = obj.getId() if obj.getId() is not None else 'seqID'


### PR DESCRIPTION
Protocol code updated so it can use biopython 1.79 (currently scipion requires biopython 1.76) 
Main difference between biopython 1.76-1.79 sequence alphabets are not longer supported.

tests executed:
   scipion3 tests pwem.tests.protocols.test_protocols_import_sequence.TestImportSequence
   scipion3 tests pwem.tests.data.test_data.TestSequenceHandler
