### PR TITLE
UniProt typo and alphabet initialization for export

### DIFF
--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -162,13 +162,13 @@ class SequenceHandler:
         error = ""
         if dataBase is None:
             if self.isAminoacid:
-                dataBase = 'UnitProt'
+                dataBase = 'UniProt'
             else:
                 dataBase = 'GeneBank'
 
         while counter <= retries:  # retry up to 5 times if server busy
             try:
-                if dataBase == 'UnitProt':
+                if dataBase == 'UniProt':
                     url = "http://www.uniprot.org/uniprot/%s.xml"
                     format = "uniprot-xml"
 

--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -46,7 +46,7 @@ from pwem.objects.data import Alphabet
 class SequenceHandler:
     def __init__(self, sequence=None,
                  iUPACAlphabet=Alphabet.DUMMY_ALPHABET):
-        if iUPACAlphabet == Alphabet.DUMMY_ALPHABET:
+        if iUPACAlphabet == Alphabet.DUMMY_ALPHABET or iUPACAlphabet == None:
             self.isAminoacid = None
         else:      
             self.isAminoacid =  (iUPACAlphabet <   Alphabet.AMBIGOUS_DNA_ALPHABET)

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1037,9 +1037,8 @@ class Sequence(EMObject):
     def exportToFile(self, seqFileName):
         '''Exports the sequence to the specified file'''
         import pwem.convert as emconv
-        seqAlphabet = self._alphabet.get() if self._alphabet.get() != None else Alphabet.DUMMY_ALPHABET
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            seqAlphabet)
+                                            self._alphabet.get())
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1037,8 +1037,9 @@ class Sequence(EMObject):
     def exportToFile(self, seqFileName):
         '''Exports the sequence to the specified file'''
         import pwem.convert as emconv
+        seqAlphabet = self._alphabet.get() if self._alphabet.get() != None else Alphabet.DUMMY_ALPHABET
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            self._alphabet.get())
+                                            seqAlphabet)
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'


### PR DESCRIPTION
When the sequence object is initialized, if no alphabet is defined it is set as None, but this breaks the construction of the SequenceHandler. We should either initialize the Alphabet to some value when creating the Sequence object if not provided or at least do not use the None for SequenceHandler.