### PR TITLE
Refix alphabet is None.

### DIFF
--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -45,8 +45,10 @@ from pwem.objects.data import Alphabet
 
 class SequenceHandler:
     def __init__(self, sequence=None,
-                 iUPACAlphabet=Alphabet.DUMMY_ALPHABET):
-        if iUPACAlphabet == Alphabet.DUMMY_ALPHABET or iUPACAlphabet == None:
+                 iUPACAlphabet=Alphabet.DUMMY_ALPHABET, doClean=True):
+        iUPACAlphabet = Alphabet.DUMMY_ALPHABET if iUPACAlphabet is None else iUPACAlphabet
+
+        if iUPACAlphabet == Alphabet.DUMMY_ALPHABET:
             self.isAminoacid = None
         else:      
             self.isAminoacid =  (iUPACAlphabet <   Alphabet.AMBIGOUS_DNA_ALPHABET)
@@ -54,7 +56,10 @@ class SequenceHandler:
         self.alphabet = iUPACAlphabet ##  indexToAlphabet(isAminoacid, iUPACAlphabet)
 
         if sequence is not None:
-            self._sequence = cleanSequence(self.alphabet, sequence)
+            if doClean:
+                self._sequence = cleanSequence(self.alphabet, sequence)
+            else:
+                self._sequence = sequence
         else:
             self._sequence = None
 

--- a/pwem/convert/sequence.py
+++ b/pwem/convert/sequence.py
@@ -46,7 +46,7 @@ from pwem.objects.data import Alphabet
 class SequenceHandler:
     def __init__(self, sequence=None,
                  iUPACAlphabet=Alphabet.DUMMY_ALPHABET, doClean=True):
-        iUPACAlphabet = Alphabet.DUMMY_ALPHABET if iUPACAlphabet is None else iUPACAlphabet
+        iUPACAlphabet = Alphabet.DUMMY_ALPHABET if iUPACAlphabet not in Alphabet.alphabets else iUPACAlphabet
 
         if iUPACAlphabet == Alphabet.DUMMY_ALPHABET:
             self.isAminoacid = None

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1034,11 +1034,11 @@ class Sequence(EMObject):
         self._alphabet.set(Integer(seqDic['alphabet']))
         self._isAminoacids.set(Boolean(seqDic['isAminoacids']))
 
-    def exportToFile(self, seqFileName):
+    def exportToFile(self, seqFileName, doClean=True):
         '''Exports the sequence to the specified file'''
         import pwem.convert as emconv
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            self._alphabet.get())
+                                            self._alphabet.get(), doClean)
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'
@@ -1049,13 +1049,13 @@ class Sequence(EMObject):
                             #seqFiP12345 USER_SEQ 
                             # Aspartate aminotransferase, mitochondrial
 
-    def appendToFile(self, seqFileName):
+    def appendToFile(self, seqFileName, doClean=True):
         '''Exports the sequence to the specified file. If it already exists,
         the sequence is appended to the ones in the file'''
         logger.info("Appending sequence to file: %s" % seqFileName)
         import pwem.convert as emconv
         seqHandler = emconv.SequenceHandler(self.getSequence(),
-                                            Alphabet.DUMMY_ALPHABET)
+                                            Alphabet.DUMMY_ALPHABET, doClean)
         # retrieving  args from scipion object
         seqID = self.getId() if self.getId() is not None else 'seqID'
         seqName = self.getSeqName() if self.getSeqName() is not None else 'seqName'


### PR DESCRIPTION
Sorry to reopen the PR, I messed it and didn't fix it with the last, somehow it didn't raise the same error but it did another.
Also, I am asking for a second change to not make the sequence cleaning by the SequenceHandler "compulsory". It was introduced in the new alphabet configuration and it messes with the way I had to visualize the alignments.  I am building fastas with dashes ("----") to align the structures and the cleaning removes them.