### PR TITLE
Angular dist viewer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,15 @@
-V3.0.26
-   - function readFromPDBDatabase tries to download an atomic structure up to 5 times before returning  an error (before it tried only once)
-   - function retry search for fatal error messages in the output and if found,  it aborts instead of trying several times.
 V3.0.25
+   - New Angular distribution viewer (right click on any SetOfParticles or SetOfSubtomograms will list it)
+
 developers:
    - SCIPION_CANCEL_XMIPP_BINDING_WARNING defined in the environment will cancel the warning about xmipp binding missing
    - SCIPION_CANCEL_XMIPP_BINDING_WARNING defined in the github action
+   - function readFromPDBDatabase tries to download an atomic structure up to 5 times before returning  an error (before it tried only once)
+   - function retry search for fatal error messages in the output and if found,  it aborts instead of trying several times.
+   - plotter.py uses logging
+   - Plotter.plotAngularDistribution refactored: uses scatter instead of plot fo each point. It may improve performance.
+   - Plotter.plotAngularDistributionFromSet new: To plot sets with items.getTransform()
+
 V3.0.24
 users:
    - Version compatible with latest released scipion-em-chimera plugin.

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -42,7 +42,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.0.24'
+__version__ = '3.0.25'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/protocols/protocol_particles.py
+++ b/pwem/protocols/protocol_particles.py
@@ -245,7 +245,7 @@ class ProtExtractParticles(ProtParticles):
 
     def _extractMicrograph(self, mic, *args):
         """ This function should be implemented by subclasses in order
-        to picking the given micrograph. """
+        to pick the given micrograph. """
         pass
 
     # ---------- Methods to extract many micrographs at once ------------------

--- a/pwem/viewers/__init__.py
+++ b/pwem/viewers/__init__.py
@@ -40,4 +40,5 @@ from .viewer_chimera import (Chimera, ChimeraView, ChimeraClientView,
                              ChimeraDataView, ChimeraViewer, ChimeraAngDist)
 from .viewer_sequence import SequenceViewer
 from .viewer_volumes import viewerProtImportVolumes
+from .viewer_angular_dist import EMAngularDistributionViewer
 from .showj import *

--- a/pwem/viewers/viewer_angular_dist.py
+++ b/pwem/viewers/viewer_angular_dist.py
@@ -1,0 +1,59 @@
+# **************************************************************************
+# *
+# * Authors:     Pablo Conesa (pconesa@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+from pwem.viewers import EmPlotter
+from pyworkflow.viewer import Viewer
+import pwem.objects as emobj
+
+class EMAngularDistributionViewer(Viewer):
+    """ Visualize the output of protocol reconstruct swarm """
+    _label = 'Score transformation viewer'
+    _targets = [emobj.SetOfParticles, emobj.SetOfVolumes]
+
+    @staticmethod
+    def plotAngularDistribution(emSet:emobj.EMSet, histogram=False):
+
+        plotter = EmPlotter(x=1, y=1, windowTitle='Angular distribution')
+
+        plotter.plotAngularDistributionFromSet(emSet, "Angular distribution", histogram=histogram)
+
+        return plotter
+
+    def _visualize(self, outputSet: emobj.EMSet, **kwargs):
+        # Keep input object in case we need to launch
+        # a new protocol and set dependencies
+
+        views =[]
+
+        # Weird plot. Not sure if used at all:
+        # views.append(self.plotAngularDistribution(outputSet, histogram=True))
+
+        views.append(self.plotAngularDistribution(outputSet))
+
+        return views
+
+
+
+


### PR DESCRIPTION
 -New Angular distribution viewer (right click on any SetOfParticles or SetOfSubtomograms will list it)
 - Plotter.plotAngularDistribution refactored: uses scatter instead of plot for each point. It may improve performance.
 - Plotter.plotAngularDistributionFromSet new: To plot sets with items.getTransform()
