### PR TITLE
   - Use new Config.isScipionRunning to register file handlers.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@ V3.0.27
    - showj.py: uses logger
    - showj.py: javaVersion cached, javaBin taken from Config.JAVA_HOME o "java"
    - showj.py: SCIPION_JAVA_HOME takes priority over JAVA_HOME (pycharm debugging case)
+   - Use new Config.isScipionRunning to register file handlers.
+   - Use new Config.isScipionRunning to print xmipp ghost message.
+   - SetOfImages._samplingRateStr extracted to convert sampling rate to a str
 
 V3.0.26
    - Hot fix: Import volumes annotates the filename in the volume/s

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -225,11 +225,9 @@ def findFolderWithPattern(path, pattern):
     else:
         return findFolderWithPattern(previous, pattern)
 
-# NOTE: This should not happen in production since tifffile is in the requirements and end up in the package metadata
-# The case for this is the "devel installation", that is not using requirements.txt (maybe it should) but directly
-# running pip install -e path/to/scipion-em
-# This triggers the import of tifffile not yet installed, but about to do so.
-with weakImport("tifffile"):
+# This should only happen when scipion is running and not when just imports are happening
+# e.g.: python console usage or plugin packaging (imports triggered by setup.py).
+if pw.Config.isScipionRunning():
     # register file handlers to preview info in the Filebrowser....
     from pyworkflow.gui.browser import FileTreeProvider, STANDARD_IMAGE_EXTENSIONS
     from .viewers.filehandlers import *
@@ -240,6 +238,6 @@ with weakImport("tifffile"):
              '.xmp', '.tif', '.tiff', '.spi', '.mrc', '.map', '.raw',
              '.inf', '.dm3', '.em', '.pif', '.psd', '.spe', '.ser', '.img',
              '.hed', *STANDARD_IMAGE_EXTENSIONS)
-    register(VolFileHandler(), '.vol', '.hdf')
-    register(StackHandler(), '.stk', '.mrcs', '.st', '.pif', '.dm4')
+    register(VolFileHandler(), '.vol', '.hdf', '.rec')
+    register(StackHandler(), '.stk', '.mrcs', '.st', '.pif', '.dm4', '.ali')
     register(ChimeraHandler(), '.bild', '.mrc', '.pdb', '.vol', '.hdf', '.cif', '.mmcif')

--- a/pwem/emlib/_libNone.py
+++ b/pwem/emlib/_libNone.py
@@ -60,8 +60,9 @@ def linkXmippBinding():
             print("LD_LIBRARY_PATH must contain scipion lib folder (%s).  Please, add it." % os.path.abspath(
                 pw.Config.getLibFolder()))
 
+cancelWarning = os.environ.get("SCIPION_CANCEL_XMIPP_BINDING_WARNING", False)
 
-if os.environ.get("SCIPION_CANCEL_XMIPP_BINDING_WARNING", None) is None:
+if (not cancelWarning) and pw.Config.isScipionRunning():
     print(ghostStr)
 
 linkXmippBinding()

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1435,6 +1435,12 @@ class SetOfImages(EMSet):
 
     def __str__(self):
         """ String representation of a set of images. """
+        s = "%s (%d items, %s, %s%s)" % \
+            (self.getClassName(), self.getSize(),
+             self._dimStr(), self._samplingRateStr(), self._appendStreamState())
+        return s
+    def _samplingRateStr(self):
+        """ Returns how the sampling rate is presented in a 'str' context."""
         sampling = self.getSamplingRate()
 
         if not sampling:
@@ -1442,10 +1448,7 @@ class SetOfImages(EMSet):
                   % self.getName())
             sampling = -999.0
 
-        s = "%s (%d items, %s, %0.2f Å/px%s)" % \
-            (self.getClassName(), self.getSize(),
-             self._dimStr(), sampling, self._appendStreamState())
-        return s
+        return "%0.2f Å/px" % sampling
 
     def _dimStr(self):
         """ Return the string representing the dimensions. """


### PR DESCRIPTION
   - Use new Config.isScipionRunning to print xmipp ghost message.
   - SetOfImages._samplingRateStr extracted to convert sampling rate to a str
Needs: https://github.com/scipion-em/scipion-pyworkflow/pull/437