### PR TITLE
Fixed typo

### DIFF
--- a/pwem/protocols/protocol_import/sequence.py
+++ b/pwem/protocols/protocol_import/sequence.py
@@ -373,7 +373,7 @@ class ProtImportSequence(ProtImportFiles):
         isAminoacid=(self.inputSequence == Alphabet.AMINOACIDS)
         if self.uniProtSequence.get() is not None:
             seqHandler = emconv.SequenceHandler(iUPACAlphabet=Alphabet.EXTENDED_PROTEIN_ALPHABET)
-            dataBase = 'UnitProt'
+            dataBase = 'UniProt'
 
         elif self._getGeneBankID() is not None:
             if isAminoacid:


### PR DESCRIPTION
Replaced UnitProt by UniProt (at least one case in which the protocol to import sequences (pwem/protocols/protocol_import/sequence.py) didn't work: G1U9Q8, HBB_MELGA)