### PR TITLE
Bug fix: Dimension errors with new copyInfo

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -1377,7 +1377,7 @@ class SetOfImages(EMSet):
         """ Copy basic information (sampling rate and ctf)
         from other set of images to current one"""
         if type(self) is type(other):
-            self.copy(other, copyId=False)
+            self.copy(other, copyId=False, ignoreAttrs=['_mapperPath', '_size', '_streamState', '_firstDim'])
         else:
             self.copyAttributes(other, '_samplingRate', '_isPhaseFlipped',
                                 '_isAmplitudeCorrected', '_alignment')


### PR DESCRIPTION
When copyInfo is called with a `SetOfParticles`, the new copy call will also add the image dimension information. In protocols changing these dimensions (i.e. doing a cropping or resizing), the previous behaviour results in a wrong registration of the new image dimensions.

Therefore, the attribute `_firstDim` has been added to the ´ignoreAttrs´ list to fix the previous issue.