### PR TITLE
   Users:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 V3.3.0:
+   Users:
+     - Fix: importing non cubic volumes could render 0 elements in dimensions. Now minimum is 1.
    Developers:
      - ImageHandler.getDimensions uses ImageReader registry and its readers (Xmipp, Tiff, Eman, ...)image
+     - User subset: ready for new metadata viewer using txt files with ids.
 
 V3.2.2; Hotfix: bugy logline commented
 

--- a/pwem/convert/headers.py
+++ b/pwem/convert/headers.py
@@ -234,7 +234,7 @@ class Ccp4Header:
 
     def getNumberOfObjects(self):
         # Special case for volume stacks...
-        return int(self._header['NS'] / self._header['NZ'])
+        return max(int(self._header['NS'] / self._header['NZ']),1)
 
     def getXYZN(self):
         if self.getISPG() and not self.isMovie:


### PR DESCRIPTION
     - Fix: importing non cubic volumes could render 0 elements in dimensions. Now minimum is 1.
   Developers:
     - ImageHandler.getDimensions uses ImageReader registry and its readers (Xmipp, Tiff, Eman, ...)image
     - User subset: ready for new metadata viewer using txt files with ids.