### PR TITLE
fix tiff dimensions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,17 +2,18 @@ V3.3.0:
    Users:
      - Fix: importing non cubic volumes could render 0 elements in dimensions. Now minimum is 1.
    Developers:
-     - ImageHandler.getDimensions uses ImageReader registry and its readers (Xmipp, Tiff, Eman, ...)image
+     - ImageHandler.getDimensions uses ImageReader registry and its readers (Xmipp, Tiff, Eman, ...) image
+     - tiff dimensions (gain, eer, tif, tiff) are swap. They originall  y were opposite to xmipp and others convention.
      - User subset: ready for new metadata viewer using txt files with ids.
 
-V3.2.2; Hotfix: bugy logline commented
+V3.2.2; Hotfix: buggy logline commented
 
 V3.2.1: Hotfix: set dimensions are updated upon set creation
 
 V3.2.0:
  Users:
    - New viewer: "Basic MD viewer" to allow doing manual subsets on those sets where before it wasn't possible (Coordinates2D, FSCs)
-   - ImajeJ filehandler: Set IMAGEJ_BINARY_PATH to the ImageJ or Fiji binary.
+   - ImageJ filehandler: Set IMAGEJ_BINARY_PATH to the ImageJ or Fiji binary.
    Developers:
      - SetOfCoordinates tweaks: better use of micrographs pointer
 

--- a/pwem/constants.py
+++ b/pwem/constants.py
@@ -204,15 +204,17 @@ RESIDUES1TO3 = {v: k for k, v in RESIDUES3TO1.items()}
 # File extensions
 # MRC
 EXT_MRC ="mrc"
-EXT_MRC_MRC="%s:%s" % (EXT_MRC,EXT_MRC)
 EXT_MRCS ="mrcs"
+EXT_MRC_MRC="%s:%s" % (EXT_MRC,EXT_MRC)
 EXT_MRC_MRCS="%s:%s" % (EXT_MRC,EXT_MRCS)
+EXT_MRCS_MRC="%s:%s" % (EXT_MRCS,EXT_MRC)
+EXT_MRCS_MRCS="%s:%s" % (EXT_MRCS,EXT_MRCS)
 EXT_ST ="st"
 EXT_REC = "rec"
 EXT_ALI = "ali"
 EXT_MAP = "map"
 
-ALL_MRC_EXTENSIONS =[EXT_MRC, EXT_MRCS, EXT_MRC_MRC, EXT_MRC_MRCS,
+ALL_MRC_EXTENSIONS =[EXT_MRC, EXT_MRCS, EXT_MRC_MRC, EXT_MRC_MRCS, EXT_MRCS_MRC, EXT_MRCS_MRCS,
                      EXT_ST, EXT_REC, EXT_ALI, EXT_MAP]
 
 ALL_TIF_EXTENSIONS = ['tif','tiff', 'gain', 'eer']

--- a/pwem/convert/headers.py
+++ b/pwem/convert/headers.py
@@ -324,10 +324,10 @@ class Ccp4Header:
 
         if ext == '.mrcs':
             self.isMovie = True
-        elif ext == '.mrc:mrcs':  # Movie --> dims = [X, Y, Z = 1, N]
+        elif ':mrcs' in ext :  # Movie --> dims = [X, Y, Z = 1, N]
             self.isMovie = True
             fileName = fileName.replace(':mrcs', '')
-        elif ext in ['.mrc:mrc', '.map:mrc']:  # Volume --> dims = [X, Y, Z, N = 1]
+        elif ':mrc' in ext:  # Volume --> dims = [X, Y, Z, N = 1]
             fileName = fileName.replace(':mrc', '')
 
         return fileName

--- a/pwem/emlib/image/image_handler.py
+++ b/pwem/emlib/image/image_handler.py
@@ -612,8 +612,15 @@ class TiffImageReader(ImageReader):
         tif = TiffFile(filePath)
         frames = len(tif.pages)  # number of pages in the file
         page = tif.pages[0]  # get shape and dtype of the image in the first page
-        x, y = page.shape
-        return x, y, frames, 1
+
+        # TO confirm but dimensions seems to be swap or at least in synx with page.axes
+        # So we are using axes attribute to get x and y
+        x, y = page.shape # IMPORTANT: to match xmipp convention
+        axes = page.axes.lower()
+        if axes.startswith("y"):
+            x,y = y,x
+
+        return x, y, 1, frames
 
 class EMANImageReader(ImageReader):
     """ Image reader for eman file formats"""

--- a/pwem/tests/data/test_data.py
+++ b/pwem/tests/data/test_data.py
@@ -240,8 +240,10 @@ class TestImageHandler(unittest.TestCase):
         tifffileLogger = logging.getLogger("tifffile.tifffile")
         tifffileLogger.disabled = True
 
-        X, Y, Z, N = ih.getDimensions(self.dsFormat.getFile("eer"))
-        self.assertEqual([X, Y, Z, N], [4096, 4096, 567, 1])
+        eerFile = self.dsFormat.getFile("eer")
+        logger.info("Reading dimension for %s" % eerFile )
+        X, Y, Z, N = ih.getDimensions(eerFile)
+        self.assertEqual([X, Y, Z, N], [4096, 4096, 1, 567])
 
     def test_convertMicrographs(self):
         """ Convert micrographs to different formats.
@@ -293,6 +295,7 @@ class TestImageHandler(unittest.TestCase):
         """
         micFn = self.dsFormat.getFile('c3-adp-se-xyz-0228_200.tif')
 
+        logger.info("Reading and converting %s" % micFn)
         ih = emlib.image.ImageHandler()
         # Check that we can read the dimensions of the dm4 file:
         EXPECTED_SIZE = (7676, 7420, 1, 38)


### PR DESCRIPTION
This fixes tiff dimensions now done with tifffile package for eer, tif, tiff and gain.

These are some results of my tests:

*Scipion*
pablo@youyou ~ $ scipion python
Scipion v3.3.0 - Eugenius
Python 3.8.5 (default, Jul 28 2020, 12:59:40) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pwem.emlib.image import ImageHandler
>>> ih = ImageHandler()
>>> ih.getDimensions("/home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif")
(7676, 7420, 1, 38)

*eman*
pablo@youyou ~ $ scipion e2iminfo.py /home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif
Scipion v3.3.0 - Eugenius
eman/sparx command detected
/home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif	 38 images in TIFF format 	7676 x 7420
38 total images

*xmipp*
pablo@youyou ~ $ scipion xmipp_image_header /home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif
Scipion v3.3.0 - Eugenius
Xmipp command detected
Input File: /home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif

--- File information ---
Filename       : /home/pablo/software/scipion/data/tests/movies/c3-adp-se-xyz-0228_200.tif
Endianess      : Little
Reversed       : False
Data type      : Unsigned character or byte type (UInt8)
Data offset    : 0
--- Image information ---
Image type     : Real-space image
Dimensions     : 38 x 1 x 7420 x 7676  ((N)Objects x (Z)Slices x (Y)Rows x (X)Columns)
Sampling rate  : 
                 X-rate (Angstrom/pixel) = 0.554005
                 Y-rate (Angstrom/pixel) = 0.554005
                 Z-rate (Angstrom/pixel) = 0.554005
