### PR TITLE
classifyItems method: updates an existing output sets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+V3.3.1:
+    Developers:
+     - classifyItems method of SetOfClasses updates an existing output set than can be utilized for streaming protocols
+
 V3.3.0:
    Users:
      - Fix: importing non cubic volumes could render 0 elements in dimensions. Now minimum is 1.

--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -2187,6 +2187,15 @@ class SetOfClasses(EMSet):
         itemDataIter = itemDataIterator  # shortcut
 
         clsDict = {}  # Dictionary to store the (classId, classSet) pairs
+        if not self.isEmpty():
+            for item in self.iterItems():
+                # clone with a param to clone also mapper path?
+                clone = item.clone()
+                self._setItemMapperPath(clone)
+                # Maybe enableAppend of class based on enableAppend of set?
+                clone.enableAppend()
+                clsDict[item.getObjId()] = clone
+
         inputSet = self.getImages()
         iterParams = iterParams or {}
 


### PR DESCRIPTION
- This can be used for streaming protocols such as xmipp PCA streaming classification