### PR TITLE
fix getObjDict in join sets

### DIFF
--- a/pwem/protocols/protocol_sets.py
+++ b/pwem/protocols/protocol_sets.py
@@ -262,9 +262,9 @@ class ProtUnionSet(ProtSets):
                 self.cleanExtraAttributes(value, verifyAttrs,
                                           prefixedAttribute + ".")
 
-    def getObjDict(self, includeClass=False, includeBasic=False):
-        return super(ProtUnionSet, self).getObjDict(
-            includeClass=includeClass, includeBasic=includeBasic)
+    # def getObjDict(self, includeClass=False, includeBasic=False):
+    #     return super(ProtUnionSet, self).getObjDict(
+    #         includeClass=includeClass, includeBasic=includeBasic)
 
     def duplicatedIds(self):
         """ Check if there are duplicated ids to renumber from


### PR DESCRIPTION
default getObjDict has an extra para that joint set wasn¡t implementing. SInce it does not do anything different it is comented