### PR TITLE
Rm wait

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+V3.5.0
+  Users:
+     - add wait protocol. This protocol wait N seconds and then ends.
+       It is helpfull to schedule other protocols using the option "wait for"
 V3.4.0:
    Users:
      - Improving performance of the metadataviewer.

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -42,7 +42,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/protocols/__init__.py
+++ b/pwem/protocols/__init__.py
@@ -67,4 +67,4 @@ from .protocol_boxsize_checkpoint import ProtBoxSizeCheckpoint
 from .protocol_mathematical_operator import ProtMathematicalOperator
 
 from .protocol_tools import *
-
+from .protocol_wait import ProtWait

--- a/pwem/protocols/protocol_wait.py
+++ b/pwem/protocols/protocol_wait.py
@@ -1,0 +1,53 @@
+# **************************************************************************
+# *
+# * Authors:     Roberto Marabini(roberto@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.protocol.params as params
+from pwem.protocols import EMProtocol
+import time
+
+class ProtWait(EMProtocol):
+    """
+    Auxiliary protocol, it just waits "seconds" seconds and then exits
+    """
+    _label = 'wait'
+
+    def _defineParams(self, form):
+        """
+        Defines the parameters the protocol form will show and its behaviour
+        :param form:
+        """
+        form.addSection(label='Input')
+        form.addParam('seconds', params.IntParam,
+                      label='wait(seconds)',
+                      help='Number of seconds the protocol waits untill it exits.')
+
+    def _insertAllSteps(self):
+        self._insertFunctionStep('createOutput')
+
+    def createOutput(self):
+        """ Save the output set."""
+        time.sleep(self.seconds.get())
+

--- a/pwem/tests/protocols/test_protocol_wait.py
+++ b/pwem/tests/protocols/test_protocol_wait.py
@@ -1,0 +1,50 @@
+# ***************************************************************************
+# * Authors:     Roberto Marabini
+# *
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# ***************************************************************************/
+from pyworkflow.tests import BaseTest, setupTestProject
+from pwem.protocols.protocol_wait import ProtWait 
+from timeit import default_timer as timer
+
+class TestProtWait(BaseTest):
+    """ Test wait protocol"""
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+
+    def testwait(self):
+        # Calculate a manual operation
+        seconds = 60
+
+        # Feed the protocol with boxSize1
+        # Calculate an average and surpassing thresholds
+        start = timer()
+        protWait = self.newProtocol(ProtWait,
+                                    seconds=seconds,
+                                   )
+
+        self.launchProtocol(protWait)
+        end = timer()
+        interval = end - start
+        self.assertTrue(interval > 60)
+        self.assertTrue(interval < 300)


### PR DESCRIPTION
added protocol "wait". This protocol sleeps for N seconds (value provided by de user) and then ends. The wait protocol is useful to schedule the start of other protocols using the "wait for" feature.

Why I find the procotol wait useful? Many protocols allow the use of a scratch disk. That  is, the data is copied before the protocol execution from a slow (magnetic) disk to a faster (solid state) disk. If two process (data copies) access at the same time to the magnetic disk the performance drops dramatically. So I :
   (1) launch  the data hungry protocol A with the  scratch disk option on and  get a estimation of the copy time
   (2) start the wait protocol with that number of seconds
   (3) launch the second data hungry protocol B with "wait for" pointing to wait

This approach is much, much more faster than start both protocols at the same time and let then compete for the hard disk.
