### PR TITLE
new variable chimeraPythonFileName for chimeraX 1.6

### DIFF
--- a/pwem/viewers/viewer_chimera.py
+++ b/pwem/viewers/viewer_chimera.py
@@ -38,6 +38,7 @@ from pwem.objects import SetOfAtomStructs
 
 chimeraPdbTemplateFileName = "Atom_struct__%06d.cif"
 chimeraMapTemplateFileName = "Map__%06d.mrc"
+chimeraPythonFileName = "chimeraScript.py"
 chimeraScriptFileName = "chimeraScript.cxc"
 chimeraConfigFileName = "chimera.ini"
 sessionFile = "SESSION.cxs"


### PR DESCRIPTION

Since chimeraX version has been updated to 1.6 we have added the following new variable:chimeraPythonFileName

All scripts using python commands must ending the file name in .py. Then we need to differentiate files using chimera commands from python commands. So, a new variable called chimeraPythonFileName has been defined to name files with python commands. Therefore the old variable chimeraScriptFileName will be used to name files with chimera commands:

chimeraPythonFileName = "chimeraScript.py"
chimeraScriptFileName = "chimeraScript.cxc"


