### PR TITLE
add symmetry option to export_DB protocol

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ V3.5.0
      - add wait protocol. This protocol wait N seconds and then ends.
        It is helpfull to schedule other protocols using the option "wait for"
      - Fix: .em files are handled by xmipp (dimensions now are correct)
+     - Add symmetry option to export_DB protocol. This will produce the list 
+       of symmetry matrices that PDBe asks for when deposition a new atomic structure
 V3.4.0:
    Users:
      - Fix: CTFTomoSeries manual subset should work

--- a/pwem/tests/protocols/test_protocol_export2DB.py
+++ b/pwem/tests/protocols/test_protocol_export2DB.py
@@ -34,7 +34,9 @@ import pwem.protocols as emprot
 import pwem.constants as emcts
 from .test_protocols_import_volumes import createFeatVolume
 
+from pwem.constants import SYM_I222r, SCIPION_SYM_NAME
 
+                            
 class TestExport2DataBases(pwtest.BaseTest):
     @classmethod
     def runImportVolumes(cls, pattern, samplingRate, label):
@@ -307,3 +309,21 @@ class TestExport2DataBases(pwtest.BaseTest):
         self.assertTrue(os.path.exists(nameFsc))
         self.assertTrue(os.path.exists(nameAtomStruct))
         # assert results
+
+    def test_symmetry(self):
+        """ If the input is a 3D map with half volumes associated
+            Save them to the output directory
+            Also create a mask and export it
+        """
+        protExp = self.newProtocol(emprot.ProtExportDataBases)
+        protExp.setObjLabel("export to DB\nsymmetry")
+        protExp.exportSymmetryGrp.set(SYM_I222r)
+        # protExp.symmetryOrder.set(self._importAtomStructCIF())
+
+        protExp.filesPath.set(os.getcwd() + "/dir4")
+        self.launchProtocol(protExp)
+
+        dirName = protExp.filesPath.get()
+        nameSymmetryMatrices = os.path.join(dirName, protExp.SYMNAME % SCIPION_SYM_NAME[SYM_I222r])
+        self.assertTrue(os.path.exists(nameSymmetryMatrices))
+


### PR DESCRIPTION
When submitting  an atomic model to PDBe a list of matrices describing the symmetry need to be provided.
If this option is selected a file with this list of matrices is created
