### PR TITLE
FlexHub data model moved to scipion-em

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ V3.5.0
        of symmetry matrices that PDBe asks for when deposition a new atomic structure
   Developers:
      - Add method setWrongDefocus to CTFModel (code centralization)
+     - Add FlexHub model (objects and base methods)
 V3.4.0:
    Users:
      - Fix: CTFTomoSeries manual subset should work

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -44,7 +44,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.5.1'
+__version__ = '3.5.0'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -44,7 +44,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.5.0'
+__version__ = '3.5.1'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/objects/__init__.py
+++ b/pwem/objects/__init__.py
@@ -27,3 +27,4 @@
 
 from .data import *
 from .data_tiltpairs import *
+from .data_flexhub import *

--- a/pwem/objects/data_flexhub.py
+++ b/pwem/objects/data_flexhub.py
@@ -108,7 +108,7 @@ class FlexInfo(EMObject):
     def setProgName(self, progName):
         self._progName = String(progName)
 
-    def set(self, attrName, value):
+    def setAttr(self, attrName, value):
         if isinstance(value, float):
             setattr(self, attrName, Float(value))
         elif isinstance(value, int):
@@ -123,7 +123,7 @@ class FlexInfo(EMObject):
         else:
             setattr(self, attrName, value)
 
-    def get(self, attrName):
+    def getAttr(self, attrName):
         return getattr(self, attrName).get()
 
 

--- a/pwem/objects/data_flexhub.py
+++ b/pwem/objects/data_flexhub.py
@@ -1,0 +1,323 @@
+# **************************************************************************
+# *
+# * Authors:     David Herreros Calero (dherreros@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+
+import numpy as np
+
+from pwem.objects import (SetOfParticles, Particle, SetOfClasses, Volume, Transform, SetOfImages,
+                          AtomStruct, EMSet, SetOfAtomStructs, EMObject, NO_INDEX)
+
+from pyworkflow.object import String, CsvList
+
+
+class ParticleFlex(Particle):
+    """Particle with flexibility information stored"""
+
+    def __init__(self, progName="", **kwargs):
+        Particle.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName)
+        self._zFlex = CsvList()
+        self._zRed = CsvList()
+        self._transform = Transform()
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+    def getZFlex(self):
+        return np.fromstring(self._zFlex.get(), sep=",")
+
+    def setZFlex(self, zFlex):
+        csvZFlex = CsvList()
+        for c in zFlex:
+            csvZFlex.append(c)
+        self._zFlex = csvZFlex
+
+    def getZRed(self):
+        return np.fromstring(self._zRed.get(), sep=",")
+
+    def setZRed(self, zRed):
+        csvZRed = CsvList()
+        for c in zRed:
+            csvZRed.append(c)
+        self._zRed = csvZRed
+
+    def copyInfo(self, other):
+        self.copy(other, copyId=False)
+
+
+class SetOfParticlesFlex(SetOfParticles):
+    """SetOfParticles with flexibility information stored"""
+    ITEM_TYPE = ParticleFlex
+
+    def __init__(self, progName="", **kwargs):
+        SetOfParticles.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName)
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+    def copyInfo(self, other):
+        super(SetOfParticles, self).copyInfo(other)
+        if hasattr(other, "_flexInfo"):
+            self._flexInfo.copyInfo(other._flexInfo)
+
+
+class FlexInfo(EMObject):
+    """ Object storing any information needed by other protocols/plugins to work properly such us
+    neural network paths, basis degrees..."""
+
+    def __init__(self, progName="", **kwargs):
+        EMObject.__init__(self, **kwargs)
+        self._progName = String(progName)
+
+    def copyInfo(self, other):
+        self.copy(other, copyId=False)
+
+    def getProgName(self):
+        return self._progName.get()
+
+    def setProgName(self, progName):
+        self._progName = String(progName)
+
+
+class VolumeFlex(Volume):
+    """Volume with flexibility information stored"""
+
+    def __init__(self, progName="", **kwargs):
+        Volume.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName=progName)
+        self._zFlex = CsvList()
+        self._zRed = CsvList()
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+    def getZFlex(self):
+        return np.fromstring(self._zFlex.get(), sep=",")
+
+    def setZFlex(self, zFlex):
+        csvZFlex = CsvList()
+        for c in zFlex:
+            csvZFlex.append(c)
+        self._zFlex = csvZFlex
+
+    def getZRed(self):
+        return np.fromstring(self._zRed.get(), sep=",")
+
+    def setZRed(self, zRed):
+        csvZRed = CsvList()
+        for c in zRed:
+            csvZRed.append(c)
+        self._zRed = csvZRed
+
+    def copyInfo(self, other):
+        self.copy(other, copyId=False)
+
+
+class SetOfVolumesFlex(SetOfImages):
+    """Represents a set of Volumes with flexibility information stored"""
+    ITEM_TYPE = VolumeFlex
+    REP_TYPE = VolumeFlex
+
+    # Hint to GUI components to expose internal items for direct selection
+    EXPOSE_ITEMS = True
+
+    def __init__(self, progName="", **kwargs):
+        SetOfImages.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName=progName)
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+
+class ClassFlex(SetOfParticlesFlex):
+    """Class3D with flexibility information stored"""
+    REP_TYPE = VolumeFlex
+    def copyInfo(self, other):
+        """ Copy basic information (id and other properties) but not
+        _mapperPath or _size from other set of micrographs to current one.
+        """
+        self.copy(other, copyId=False, ignoreAttrs=['_mapperPath', '_size'])
+
+    def clone(self):
+        clone = self.getClass()()
+        clone.copy(self, ignoreAttrs=['_mapperPath', '_size'])
+        return clone
+
+    def close(self):
+        # Do nothing on close, since the db will be closed by SetOfClasses
+        pass
+
+
+class SetOfClassesFlex(SetOfClasses):
+    """ SetOfClasses3D with flexibility information stored"""
+    ITEM_TYPE = ClassFlex
+    REP_TYPE = VolumeFlex
+    REP_SET_TYPE = SetOfVolumesFlex
+
+    pass
+
+
+class AtomStructFlex(AtomStruct):
+    """ AtomStruct with flexibility information stored"""
+
+    def __init__(self, progName="", **kwargs):
+        AtomStruct.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName)
+        self._zFlex = CsvList()
+        self._zRed = CsvList()
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+    def getZFlex(self):
+        return np.fromstring(self._zFlex.get(), sep=",")
+
+    def setZFlex(self, zFlex):
+        csvZFlex = CsvList()
+        for c in zFlex:
+            csvZFlex.append(c)
+        self._zFlex = csvZFlex
+
+    def getZRed(self):
+        return np.fromstring(self._zRed.get(), sep=",")
+
+    def setZRed(self, zRed):
+        csvZRed = CsvList()
+        for c in zRed:
+            csvZRed.append(c)
+        self._zRed = csvZRed
+
+    def copyInfo(self, other):
+        self.copy(other, copyId=False)
+
+    def setLocation(self, *args):
+        """ Set the image location, see getLocation.
+        Params:
+            First argument can be:
+             1. a tuple with (index, filename)
+             2. a index, this implies a second argument with filename
+             3. a filename, this implies index=NO_INDEX
+        """
+        first = args[0]
+        t = type(first)
+        if t == tuple:
+            _, filename = first
+        elif t == int:
+            _, filename = first, args[1]
+        elif t == str:
+            _, filename = NO_INDEX, first
+        else:
+            raise Exception('setLocation: unsupported type %s as input.' % t)
+
+        self.setFileName(filename)
+
+    def getSamplingRate(self):
+        # This is only a way to use the default way to generate subsets
+        return None
+
+    def setSamplingRate(self, sr):
+        # This is only a way to use the default way to generate subsets
+        pass
+
+    def setAlignment(self, sr):
+        # This is only a way to use the default way to generate subsets
+        pass
+
+
+class SetOfAtomStructFlex(SetOfAtomStructs):
+    """ Set containing AtomStructFlex items. """
+    ITEM_TYPE = AtomStructFlex
+    EXPOSE_ITEMS = True
+
+    def __init__(self, progName="", **kwargs):
+        EMSet.__init__(self, **kwargs)
+        self._flexInfo = FlexInfo(progName)
+
+    def getFlexInfo(self):
+        return self._flexInfo
+
+    def setFlexInfo(self, flexInfo):
+        self._flexInfo = flexInfo
+
+    def copyInfo(self, other):
+        super(SetOfAtomStructFlex, self).copyInfo(other)
+        if hasattr(other, "_flexInfo"):
+            self._flexInfo.copyInfo(other._flexInfo)
+
+    def getSamplingRate(self):
+        # This is only a way to use the default way to generate subsets
+        return None
+
+    def setSamplingRate(self, sr):
+        # This is only a way to use the default way to generate subsets
+        pass
+
+    def setAlignment(self, sr):
+        # This is only a way to use the default way to generate subsets
+        pass
+
+
+class ClassStructFlex(SetOfParticlesFlex):
+    """Class3D with flexibility information stored for structures"""
+    REP_TYPE = AtomStructFlex
+    def copyInfo(self, other):
+        """ Copy basic information (id and other properties) but not
+        _mapperPath or _size from other set of micrographs to current one.
+        """
+        self.copy(other, copyId=False, ignoreAttrs=['_mapperPath', '_size'])
+
+    def clone(self):
+        clone = self.getClass()()
+        clone.copy(self, ignoreAttrs=['_mapperPath', '_size'])
+        return clone
+
+    def close(self):
+        # Do nothing on close, since the db will be closed by SetOfClasses
+        pass
+
+class SetOfClassesStructFlex(SetOfClasses):
+    """ SetOfClasses3D with flexibility information stored for structures"""
+    ITEM_TYPE = ClassStructFlex
+    REP_TYPE = AtomStructFlex
+    REP_SET_TYPE = SetOfAtomStructFlex
+
+    pass

--- a/pwem/objects/data_flexhub.py
+++ b/pwem/objects/data_flexhub.py
@@ -30,7 +30,7 @@ import numpy as np
 from pwem.objects import (SetOfParticles, Particle, SetOfClasses, Volume, Transform, SetOfImages,
                           AtomStruct, EMSet, SetOfAtomStructs, EMObject, NO_INDEX)
 
-from pyworkflow.object import String, CsvList
+from pyworkflow.object import String, CsvList, Float, Integer
 
 
 class ParticleFlex(Particle):
@@ -107,6 +107,24 @@ class FlexInfo(EMObject):
 
     def setProgName(self, progName):
         self._progName = String(progName)
+
+    def set(self, attrName, value):
+        if isinstance(value, float):
+            setattr(self, attrName, Float(value))
+        elif isinstance(value, int):
+            setattr(self, attrName, Integer(value))
+        elif isinstance(value, str):
+            setattr(self, attrName, String(value))
+        elif isinstance(value, list) or isinstance(value, np.ndarray):
+            csv = CsvList()
+            for c in value:
+                csv.append(c)
+            setattr(self, attrName, csv)
+        else:
+            setattr(self, attrName, value)
+
+    def get(self, attrName):
+        return getattr(self, attrName).get()
 
 
 class VolumeFlex(Volume):

--- a/pwem/protocols/__init__.py
+++ b/pwem/protocols/__init__.py
@@ -70,3 +70,5 @@ from .protocol_mathematical_operator import ProtMathematicalOperator
 
 from .protocol_tools import *
 from .protocol_wait import ProtWait
+
+from .protocol_base_flexhub import *

--- a/pwem/protocols/protocol_base_flexhub.py
+++ b/pwem/protocols/protocol_base_flexhub.py
@@ -1,0 +1,87 @@
+# **************************************************************************
+# *
+# * Authors:     David Herreros Calero (dherreros@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+
+import pyworkflow as pw
+from pyworkflow.mapper.sqlite_db import SqliteDb
+from pyworkflow.utils.properties import Message
+
+import pwem.objects.data_flexhub as pwobj
+
+
+class ProtFlexBase:
+    def _createSet(self, SetClass, template, suffix, **kwargs):
+        """ Create a set and set the filename using the suffix.
+        If the file exists, it will be deleted. """
+        setFn = self._getPath(template % suffix)
+        # Close the connection to the database if
+        # it is open before deleting the file
+        pw.utils.cleanPath(setFn)
+
+        SqliteDb.closeConnection(setFn)
+        setObj = SetClass(filename=setFn, **kwargs)
+        return setObj
+
+    def _createSetOfParticlesFlex(self, suffix='', **kwargs):
+        return self._createSet(pwobj.SetOfParticlesFlex,
+                               'flexparticles%s.sqlite', suffix, **kwargs)
+
+    def _createSetOfClassesFlex(self, flexParticles, suffix='', **kwargs):
+        classes = self._createSet(pwobj.SetOfClassesFlex,
+                                  'flexClasses%s.sqlite', suffix, **kwargs)
+        classes.setImages(flexParticles)
+        return classes
+
+    def _createSetOfClassesStructFlex(self, flexParticles, suffix='', **kwargs):
+        classes = self._createSet(pwobj.SetOfClassesStructFlex,
+                                  'flexClassesStruct%s.sqlite', suffix, **kwargs)
+        classes.setImages(flexParticles)
+        return classes
+
+    def _createSetOfVolumesFlex(self, suffix='', **kwargs):
+        return self._createSet(pwobj.SetOfVolumesFlex,
+                               'flexvolumes%s.sqlite', suffix, **kwargs)
+
+    def _createSetOfAtomStructFlex(self, suffix='', **kwargs):
+        return self._createSet(pwobj.SetOfAtomStructFlex,
+                               'flexstructs%s.sqlite', suffix, **kwargs)
+
+    def _getOutputSuffix(self, cls):
+        """ Get the name to be used for a new output.
+        For example: output3DCoordinates7.
+        It should take into account previous outputs
+        and number with a higher value.
+        """
+        maxCounter = -1
+        for attrName, _ in self.iterOutputAttributes(cls):
+            suffix = attrName.replace(self.OUTPUT_PREFIX, '')
+            try:
+                counter = int(suffix)
+            except:
+                counter = 1  # when there is not number assume 1
+            maxCounter = max(counter, maxCounter)
+
+        return str(maxCounter+1) if maxCounter > 0 else ''  # empty if not output

--- a/pwem/protocols/protocol_base_flexhub.py
+++ b/pwem/protocols/protocol_base_flexhub.py
@@ -32,6 +32,7 @@ from pyworkflow.utils.properties import Message
 import pwem.objects.data_flexhub as pwobj
 
 
+# FIXME: Do not use this methods and remove in the future
 class ProtFlexBase:
     def _createSet(self, SetClass, template, suffix, **kwargs):
         """ Create a set and set the filename using the suffix.


### PR DESCRIPTION
FlexHub data model has been moved to `scipion-em` to avoid extra dependencies of FlexHub related plugins to `scipion-em-flexutils`. The model includes:

- The FlexHub objects defined in `data_flexhub`
- The FlexHub base protocolo defined in `protocol_base_flexhub`. This protocol will be removed in the future to avoid having set creation methods