### PR TITLE
Extract coordinates: modify ending condition

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+v3.8.0
+  Users:
+    - Allows to run the whole workflow until 3D processing with trigger points
+
+   Developers
+    - Modify the finishing condition of the parent protocol "extract particles". Now, it checks if the input coords are closed and if all mics and CTFs have been processed.
+
 V3.7.0:
   Users:
      - Allowing drag and drop a coordinate when picking

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,3 @@
-v3.8.0
-  Users:
-    - Allows to run the whole workflow until 3D processing with trigger points
-
-   Developers
-    - Modify the finishing condition of the parent protocol "extract particles". Now, it checks if the input coords are closed and if all mics and CTFs have been processed.
-
 V3.7.0:
   Users:
      - Allowing drag and drop a coordinate when picking
@@ -17,9 +10,11 @@ V3.7.0:
      - NEW PROTOCOL - data summary: Aggregates (COUNT, MAX, MIN, AVG) any set data based on its fields
      - Importing coordinates from cryoSPARC
      - Fix: The coordinate viewer shows the complete list of micrographs when a subset has been generated and there are only coordinates for some micrographs in this subset
+     - Allows to run the whole workflow until 3D processing with trigger points
 
 Developers:
      - Plugin._defineVar and _defineEmVar offers  description(str) and  varType(VarTypes) as optional arguments to better describe the variable devel
+     - Modify the finishing condition of the parent protocol "extract particles". Now, it checks if the input coords are closed and if all mics and CTFs have been processed.
 
 V3.6.0:
   Users:

--- a/pwem/protocols/protocol_particles.py
+++ b/pwem/protocols/protocol_particles.py
@@ -313,7 +313,16 @@ class ProtExtractParticles(ProtParticles):
 
     # ------ Methods for Streaming extraction --------------
     def _isStreamClosed(self):
-        return self.micsClosed and self.ctfsClosed and self.coordsClosed
+        return self.coordsClosed
+
+    def _isAllMicsProcessed(self):
+        """
+        This condition determines if the processing is complete when all the micrographs associated
+        with the input coordinates have been processed.
+        """
+        currentPicsMics = self.inputCoordinates.get().getUniqueValues("_micName")
+
+        return len(self.micDict) == len(currentPicsMics)
 
     def _stepsCheck(self):
         # To allow streaming picking we need to detect:
@@ -519,7 +528,8 @@ class ProtExtractParticles(ProtParticles):
         # We have finished when there is not more input mics (stream closed)
         # and the number of processed mics is equal to the number of inputs
         streamClosed = self._isStreamClosed()
-        self.finished = streamClosed and allDone == inputLen
+        allMicsProcessed = self._isAllMicsProcessed()
+        self.finished = streamClosed and allDone == inputLen and allMicsProcessed
         self.debug(' is finished? %s ' % self.finished)
         self.debug(' is stream closed? %s ' % streamClosed)
         streamMode = pwobj.Set.STREAM_CLOSED if self.finished else pwobj.Set.STREAM_OPEN

--- a/pwem/protocols/protocol_particles.py
+++ b/pwem/protocols/protocol_particles.py
@@ -315,7 +315,7 @@ class ProtExtractParticles(ProtParticles):
     def _isStreamClosed(self):
         return self.coordsClosed
 
-    def _isAllMicsProcessed(self):
+    def _areAllMicsProcessed(self):
         """
         This condition determines if the processing is complete when all the micrographs associated
         with the input coordinates have been processed.
@@ -528,7 +528,7 @@ class ProtExtractParticles(ProtParticles):
         # We have finished when there is not more input mics (stream closed)
         # and the number of processed mics is equal to the number of inputs
         streamClosed = self._isStreamClosed()
-        allMicsProcessed = self._isAllMicsProcessed()
+        allMicsProcessed = self._areAllMicsProcessed()
         self.finished = streamClosed and allDone == inputLen and allMicsProcessed
         self.debug(' is finished? %s ' % self.finished)
         self.debug(' is stream closed? %s ' % streamClosed)


### PR DESCRIPTION
This protocol would not finish if both micrographs and ctf sets where closed, however there is a possibility that you were using trigger points so you dont want to use all your data, when this happened even though the input coordinates set was closed it had to wait until all the micrographs and ctfs that where not associated to those coordinates to finish. Now it will check if the input coords are closed and if you have all the ctfs and mics from the input already processed to finish without waiting for all to finish.  