### PR TITLE
Fix edit set

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+V3.9.1:
+   - Fix: CrossSubset protocol works with "id" or "_objId" field too.
+   - Fix: Edit set protocol works with complex sets (titlseries, Classes2d) but not editing subelements for now.
 V3.9.0:
  Users:
    - Chimera viewer compatible with newer versions (flatpak, deb, windows via WSL) via linking

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,14 @@
 V3.9.1:
+ Users:
    - Fix: CrossSubset protocol works with "id" or "_objId" field too.
    - Fix: Edit set protocol works with complex sets (titlseries, Classes2d) but not editing subelements for now.
+ Developers:
+   - New constants for "id" and "_objId": ID_COLUMN='id', ID_ATTRIBUTE='_objId'
 V3.9.0:
  Users:
    - Chimera viewer compatible with newer versions (flatpak, deb, windows via WSL) via linking
 
-Developers:
+ Developers:
     - Generate a stack of images or a volume from a list of PIL images using ScipionImageReader.
 
 V3.8.0:

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -47,7 +47,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.9.0'
+__version__ = '3.9.1'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/constants.py
+++ b/pwem/constants.py
@@ -220,3 +220,7 @@ ALL_MRC_EXTENSIONS =[EXT_MRC, EXT_MRCS, EXT_MRC_MRC, EXT_MRC_MRCS,
 
 
 ALL_TIF_EXTENSIONS = ['tif','tiff', 'gain', 'eer']
+
+# Id field/attrubute constants. TODO: use declarations in pyworkflow
+ID_COLUMN='id'
+ID_ATTRIBUTE='_objId'

--- a/pwem/protocols/protocol_set_editor.py
+++ b/pwem/protocols/protocol_set_editor.py
@@ -26,13 +26,13 @@
 # **************************************************************************
 
 import pyworkflow.protocol.params as params
-from pwem.protocols import EMProtocol
+from pwem.protocols.protocol_sets import ProtSets
 from pwem.objects.data import SetOfParticles
 
 import numpy as np
 
 
-class ProtSetEditor(EMProtocol):
+class ProtSetEditor(ProtSets):
     """
     Protocol to edit attributes of all the items of a set using a formula.
     This could be useful for editing some values in the set. Use this
@@ -70,9 +70,9 @@ class ProtSetEditor(EMProtocol):
         modifiedSet = inputSet.createCopy(self._getExtraPath(), copyInfo=True)
 
         for sourceItem in inputSet.iterItems():
-            item = sourceItem.clone()
+            item = sourceItem
             exec(self.formula.get())
-            modifiedSet.append(item)
+            self._append(modifiedSet, item)
 
         self.createOutput(self.inputSet, modifiedSet)
 


### PR DESCRIPTION
V3.9.1:
 Users:
   - Fix: CrossSubset protocol works with "id" or "_objId" field too.
   - Fix: Edit set protocol works with complex sets (titlseries, Classes2d) but not editing subelements for now.
 Developers:
   - New constants for "id" and "_objId": ID_COLUMN='id', ID_ATTRIBUTE='_objId'