### PR TITLE
Changes in atom structure file format

### DIFF
--- a/pwem/convert/atom_struct.py
+++ b/pwem/convert/atom_struct.py
@@ -989,31 +989,41 @@ def retry(runEnvirom, program, args, cwd, listAtomStruct=[], log=None, clean_dir
             else:
                 try:
                     if atomStructName.endswith(".pdb"):
-                        newAtomStructName = os.path.abspath(
-                            os.path.join(cwd, "retrypdb%d.cif" % i))
-                        fromPDBToCIF(atomStructName, newAtomStructName, log)
-                        _args = args.replace(atomStructName, newAtomStructName)
                         try:
-                            runEnvirom(program, _args, cwd=cwd)
-                        except:
-                            testLog(log, messages,sdterrLog)
-                            fromCIFTommCIF(newAtomStructName, newAtomStructName, log)
-                            runEnvirom(program, _args, cwd=cwd)
-                    elif atomStructName.endswith(".cif"):
-                        newAtomStructName = os.path.abspath(
-                            os.path.join(cwd, "retrycif%d.cif" % i))
-                        fromCIFTommCIF(atomStructName, newAtomStructName, log)
-                        _args = args.replace(atomStructName, newAtomStructName)
-                        try:
-                            runEnvirom(program, _args, cwd=cwd)
-                        except:
-                            testLog(log, messages,sdterrLog)
-                            newAtomStructName = os.path.abspath(
-                                os.path.join(cwd, "retrycif%d.pdb" % i))
-                            fromCIFToPDB(atomStructName, newAtomStructName, log)
+                            newAtomStructName = atomStructName.replace(atomStructName.split(".")[-1],"cif")
                             _args = args.replace(atomStructName, newAtomStructName)
                             runEnvirom(program, _args, cwd=cwd)
-                            testLog(log, messages,sdterrLog)
+                        except:
+                            newAtomStructName = os.path.abspath(
+                                os.path.join(cwd, "retrypdb%d.cif" % i))
+                            fromPDBToCIF(atomStructName, newAtomStructName, log)
+                            _args = args.replace(atomStructName, newAtomStructName)
+                            try:
+                                runEnvirom(program, _args, cwd=cwd)
+                            except:
+                                testLog(log, messages,sdterrLog)
+                                fromCIFTommCIF(newAtomStructName, newAtomStructName, log)
+                                runEnvirom(program, _args, cwd=cwd)
+                    elif atomStructName.endswith(".cif"):
+                        try:
+                            newAtomStructName = atomStructName.replace(atomStruct.split(".")[-1],"pdb")
+                            _args = args.replace(atomStructName, newAtomStructName)
+                            runEnvirom(program, _args, cwd=cwd)
+                        except:
+                            newAtomStructName = os.path.abspath(
+                                os.path.join(cwd, "retrycif%d.cif" % i))
+                            fromCIFTommCIF(atomStructName, newAtomStructName, log)
+                            _args = args.replace(atomStructName, newAtomStructName)
+                            try:
+                                runEnvirom(program, _args, cwd=cwd)
+                            except:
+                                testLog(log, messages,sdterrLog)
+                                newAtomStructName = os.path.abspath(
+                                    os.path.join(cwd, "retrycif%d.pdb" % i))
+                                fromCIFToPDB(atomStructName, newAtomStructName, log)
+                                _args = args.replace(atomStructName, newAtomStructName)
+                                runEnvirom(program, _args, cwd=cwd)
+                                testLog(log, messages,sdterrLog)
                 except:
                     testLog(log, messages,sdterrLog)
                     # first remove files or directories in the extra folder,

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -368,8 +368,15 @@ Format may be PDB or MMCIF"""
         baseName = basename(atomStructPath)
         localPath = abspath(self._getExtraPath(baseName))
 
-        if str(atomStructPath) != str(localPath):  # from local file
-            pwutils.copyFile(atomStructPath, localPath)
+        try:
+            from pwem import Domain
+            chimeraPlugin = Domain.importFromPlugin('chimera', 'Plugin', doRaise=True)
+            localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
+            args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
+            chimeraPlugin.runChimeraProgram(chimeraPlugin.getProgram(), args)
+        except ImportError:
+            if str(atomStructPath) != str(localPath):  # from local file
+                pwutils.copyFile(atomStructPath, localPath)
 
         localPath = relpath(localPath)
 


### PR DESCRIPTION
Hi all,

two files have been changed  regarding the format of atom structure files:

1.- volumes.py: Conversion of imported .pdb files into .cif through ChimeraX (the flag --nogui avoids opening ChimeraX GUI)

2.- atom-struct.py: Replaces the use of .pdb file by the .cif file when the first one fails and the second one also exists in the same folder. 