### PR TITLE
skip creating class2D is classId=0

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -2296,6 +2296,8 @@ class SetOfClasses(EMSet):
                 ref = newItem.getClassId()
                 if ref is None:
                     raise Exception('Particle classId is None!!!')
+                if ref == 0:
+                    continue
 
                 # Register a new class set if the ref was not found.
                 # if not ref in clsDict:


### PR DESCRIPTION
Relion intermediate iterations can have particles with classId=0 that do not have any class assignment yet. These should be skipped when creating classes