### PR TITLE
Hotfix: STOP_STREAMING import button fixed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+V3.9.3: hotfix
+Users:
+   - Import STOP_STREAMING button is fixed
+Developers:
+   - stop_import function needed the context for the button action
 V3.9.2:
 Users:
    - Fix: 'Volume' object has no attribute 'getCompatibilityDict' when using join sets with Volumes 

--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -47,7 +47,7 @@ from .objects import EMObject
 from .tests import defineDatasets
 from .utils import *
 
-__version__ = '3.9.2'
+__version__ = '3.9.3'
 NO_VERSION_FOUND_STR = "0.0"
 CUDA_LIB_VAR = 'CUDA_LIB'
 

--- a/pwem/protocols/protocol_import/images.py
+++ b/pwem/protocols/protocol_import/images.py
@@ -199,6 +199,8 @@ class ProtImportImages(ProtImportFiles):
             imgSet.loadAllProperties()
             self._fillImportedFiles(imgSet)
             imgSet.enableAppend()
+            if self.stopStreamingFileExists():
+                os.remove(self._getStopStreamingFilename()) # Remove stop streaming file if the import was not truly finished
         
         pointerExcludedMovs = getattr(self, 'moviesToExclude', None)
         if pointerExcludedMovs is not None:
@@ -300,7 +302,7 @@ class ProtImportImages(ProtImportFiles):
                 # special stop condition, this can be used to manually stop
                 # some protocols such as import movies
                 finished = (now - lastDetectedChange > timeout or
-                            self.streamingHasFinished())
+                            self.stopStreamingFileExists())
                 self.debug("Checking if finished:")
                 self.debug("   Now - Last Change: %s"
                            % pwutils.prettyDelta(now - lastDetectedChange))
@@ -584,7 +586,7 @@ class ProtImportImages(ProtImportFiles):
         else:
             return []
 
-    def stopImport(self):
+    def stopImport(self, e):
         """ Since the actual protocol that is running is in a different
         process that the one that this method will be invoked from the GUI,
         we will use a simple mechanism to place an special file to stop
@@ -594,5 +596,5 @@ class ProtImportImages(ProtImportFiles):
         f = open(self._getStopStreamingFilename(), 'w')
         f.close()
 
-    def streamingHasFinished(self):
+    def stopStreamingFileExists(self):
         return os.path.exists(self._getStopStreamingFilename())


### PR DESCRIPTION
The button callback needed context. It was broken. 