### PR TITLE
Remove importFromPlugin function usage

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -371,8 +371,7 @@ Format may be PDB or MMCIF"""
         localPath = abspath(self._getExtraPath(baseName))
 
         try:
-            from pwem import Domain
-            chimeraPlugin = Domain.importFromPlugin('chimera', 'Plugin', doRaise=True)
+            from chimera import Plugin as chimeraPlugin
             localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
             args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
             chimeraPlugin.runChimeraProgram(chimeraPlugin.getProgram(), args)


### PR DESCRIPTION
This PR was opened with the initial issue of `pwem.Domain.importFromPlugin` not raising the appropiate exception class.
See referenced [pyworkflow's PR](https://github.com/scipion-em/scipion-pyworkflow/pull/582).

Function `importFromPlugin` does not look like is actually needed for the purpose of the `createOutputStep` function.

Instead, it is simpler (and therefore, less likely to fail), to just import the regular way and capture the possible exception the exact same way it was being done already.

If module chimera does not exist, this will raise a `ModuleNotFoundError`, and, if for some reason, module chimera does not have name Plugin, that will raise an `ImportError`. However, as `ImportError` is parent class for `ModuleNotFoundError`, capturing it will capture both of them.