### PR TITLE
Generalize loadAcquistionInfo method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+V3.9.5:
+Users:
+  - Can use different name conventions for the acquisition info
+Developers:
+  - Generalize the name convention to load acquisition info in the import movies/micrographs
 V3.9.4:
 Users:
   - Edit set protocol works with complex sets (titlseries, Classes2d) using "Sub item formula"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,15 +1,12 @@
-V3.9.5:
-Users:
-  - Can use different name conventions for the acquisition info
-Developers:
-  - Generalize the name convention to load acquisition info in the import movies/micrographs
 V3.9.4:
 Users:
   - Edit set protocol works with complex sets (titlseries, Classes2d) using "Sub item formula"
   - Adding a prefix to the calculated columns for the metadataviewer
+  - Can use different name conventions for the acquisition info
 Developers:
    - execution mode moved to class level
    - classifyItems: report detailed information when updateItemCallback fails
+   - Generalize the name convention to load acquisition info in the import movies/micrographs
 V3.9.3: hotfix
 Users:
    - Import STOP_STREAMING button is fixed

--- a/pwem/protocols/protocol_import/micrographs.py
+++ b/pwem/protocols/protocol_import/micrographs.py
@@ -166,7 +166,7 @@ class ProtImportMicBase(ProtImportImages):
 
         for fileName, fileId in self.iterFiles():
             baseName = pwutils.removeExt(fileName)
-            xml1 = baseName.replace('_frames', '.xml')
+            xml1 = f"{baseName.rsplit('_', 1)[0]}.xml"
             if os.path.exists(xml1):
                 result = self._parseXML(xml1)
             else:


### PR DESCRIPTION
Now it does not expect an specific name convention for the acquisition information. Enhancement reported by the ESRF facility. 