### PR TITLE
Do not assume chimera plugin has binaries

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -373,7 +373,6 @@ Format may be PDB or MMCIF"""
 
         chimeraPlugin = self.__getChimeraPlugin()
         if chimeraPlugin:
-            from chimera import Plugin as chimeraPlugin
             localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
             args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
             chimeraPlugin.runChimeraProgram(chimeraPlugin.getProgram(), args)


### PR DESCRIPTION
In the GitHub Actions of scipion-em-kiharalab, we are seeing an error lately where the scipion-em protocol ProtImportPDB fails, and the reason we found is that, as our requirements file includes scipion-em-phenix, which itself includes scipion-em-ccp4, which then includes scipion-em-chimera, this last plugin is being installed with our plugin, but not the binaries for chimera.

This means that, when reaching [this line](https://github.com/scipion-em/scipion-em/blob/af16d763fb2434363f51631b507d4ec80670fcbd/pwem/protocols/protocol_import/volumes.py#L373), the import will work, as the plugin exists and can be imported, but then the operation using chimera fails because of the lack of the binaries.

To solve this, I have created a function `__getChimeraPlugin` that returns the plugin when exists and the binaries are present, or `None` otherwise, so the operation using chimera only takes place if both conditions are satisfied.