### PR TITLE
Save non import errors

### DIFF
--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -372,10 +372,11 @@ Format may be PDB or MMCIF"""
 
         try:
             from chimera import Plugin as chimeraPlugin
-            localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
-            args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
+            cifPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
+            args = f'--nogui --cmd "open {atomStructPath}; save {cifPath}; exit"'
             chimeraPlugin.runChimeraProgram(chimeraPlugin.getProgram(), args)
-        except ImportError:
+            localPath = cifPath
+        except:
             if str(atomStructPath) != str(localPath):  # from local file
                 pwutils.copyFile(atomStructPath, localPath)
 


### PR DESCRIPTION
At some point, I found that chimera raises some errors when trying to open a atomstruct and save it as cif. 
Therefore, this structure would fail.
I have modify it so regardless of the error, if Chimera cannot be used, the file is just copied