### PR TITLE
Fixing Euler angle convention in getEulerAngles()

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -149,10 +149,10 @@ class Transform(EMObject):
         M = self.getMatrix()
         return M[:3, :3]
 
-    def getEulerAngles(self):
+    def getEulerAngles(self, axes='szyz'):
         from pwem.convert.transformations import euler_from_matrix
         rotation = self.getRotationMatrix()
-        return euler_from_matrix(rotation, axes='szyz')
+        return euler_from_matrix(rotation, axes=axes)
 
     def getShifts(self):
         M = self.getMatrix()


### PR DESCRIPTION
In CryoEM we usually use the `szyz` convention for Euler Angles. Transform.getEulerAngles() returns them in the `sxyz` convention. Currently the function is not used much across plugins: https://github.com/search?q=org%3Ascipion-em%20getEulerAngles&type=code