### PR TITLE
Fixed shift in invert hand

### DIFF
--- a/pwem/protocols/protocol_alignment_invertHand.py
+++ b/pwem/protocols/protocol_alignment_invertHand.py
@@ -69,8 +69,8 @@ class ProtAlignmentInvertHand(ProtAlign2D):
             m = t.getMatrix()
             m[0, 2] *= -1.
             m[1, 2] *= -1.
-            m[2, 0] *= -1.
             m[2, 1] *= -1.
+            m[2, 0] *= -1.
             m[2, 3] *= -1.
             # particle.setTransform(t.setMatrix(m))
             outputParticles.append(particle)


### PR DESCRIPTION
Reconstructions performed after a `invert hand` protocol are blurry in the Z direction as shown in this image.
<img width="251" height="252" alt="imagen" src="https://github.com/user-attachments/assets/78c99ee6-9219-4b05-9bc3-e1ee24458da8" />

This is the shift is not being handled in the protocol. The Z component of the transform matrix should be negated as shown in the following expression.
<img width="2048" height="955" alt="imagen" src="https://github.com/user-attachments/assets/882f1659-f7a8-4356-98a5-7c27fab81f6a" />

After fixing this, the reconstruction does not look fuzzy anymore.
<img width="251" height="246" alt="imagen" src="https://github.com/user-attachments/assets/6ced3414-3306-40f6-84d6-f9c8e92cc048" />

PD: One would expect that the `shift_z` component of particles to be zero, so negating it should not have any effect. However, as they're expressed in the volume space (first rotate, them shift), they may be in fact non-zero.