### PR TITLE
Creation of new wizard to select more than one chain in an atom structure (SelectChainSWizard)

### DIFF
--- a/pwem/wizards/wizards.py
+++ b/pwem/wizards/wizards.py
@@ -293,7 +293,7 @@ class BaseChainWizard(VariableWizard    ):
 
 
 class SelectChainWizard(BaseChainWizard):
-    '''Opens the input AtomStruct and allows you to select one of the present chains'''
+    '''Opens the input AtomStruct and allows you to select ONE chain from the structure'''
     _targets, _inputs, _outputs = [], {}, {}
 
     def show(self, form, *params):
@@ -326,7 +326,7 @@ SelectChainWizard().addTarget(protocol=emprot.ProtImportSequence,
 
 class SelectChainSWizard(BaseChainWizard):
     '''Opens the input AtomStruct and allows you to select
-        MORE THAN ONE of the present chains'''
+        MULTIPLE chains (1 or more) from the structure'''
     _targets, _inputs, _outputs = [], {}, {}
 
     def show(self, form, *params):


### PR DESCRIPTION
The new wizard SelectChainSWizard is a copy of the previous existing one SelectChainWizard, which allowed to select only one chain of an atom structure, just modified to select more than one chain.

Additionally, appropriate indentation has been included in the next SelectResidueWizard wizard.