### PR TITLE
Fix MAXIT v10.x build by replacing 'mv' with 'cp' in Makefile

### DIFF
--- a/pwem/__init__.py
+++ b/pwem/__init__.py
@@ -179,7 +179,10 @@ class Plugin(pyworkflow.plugin.Plugin):
         if not env.hasPackage(MAXIT):
             MAXIT_URL = 'https://sw-tools.rcsb.org/apps/MAXIT/maxit-v10.100-prod-src.tar.gz'
             MAXIT_TAR = 'maxit-v10.100-prod-src.tar.gz'
-            maxit_commands = [('make -j 1 binary ', ['bin/maxit'])]
+            maxit_commands = [
+                ('sed -i "s/\\bmv\\b/cp/g" cifparse-obj-v7.0/Makefile', []),
+                ('make -j 1 binary', ['bin/maxit'])
+            ]
             env.addPackage(MAXIT, version='10.1',
                            tar=MAXIT_TAR,
                            url=MAXIT_URL,


### PR DESCRIPTION
### Summary
This pull request fixes the build process for MAXIT version 10.x. 
In MAXIT v10.x, the Makefile uses `mv` to rename intermediate files generated from `.y` sources. These files are required again during subsequent compilation steps, but `mv` removes them, causing build failures. To address this, `mv` is substituted to `cp` in Makefile before running `make`. 

### Changes
- Added a `sed` command to replace all `mv` with `cp` in `cifparse-obj-v7.0/Makefile` for MAXIT v10.x