### PR TITLE
JMK add Image getDim case for z-n swap like Volume

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -614,7 +614,16 @@ class Image(EMObject):
         """Return image dimensions as tuple: (Xdim, Ydim, Zdim)"""
         from pwem.emlib.image import ImageHandler
         x, y, z, n = ImageHandler().getDimensions(self)
-        return None if x is None else (x, y, z)
+
+        if x is None:
+            return None
+
+        # Some images in mrc format can have the z dimension
+        # as n dimension, so we need to consider this case.
+        if z > 1 and n == 1:
+            return x, y, n
+        else:
+            return x, y, z
 
     def getImage(self):
         """ Returns the actual image this objects represents"""


### PR DESCRIPTION
This fixes an error I got when importing particles from CryoSPARC after running blob picker, junk detector, then particle extraction. I got a particle size of 256, 256, 149 but actually 149 is the number of images in the first mrc file. 

With the fix, I get 256, 256 like expected.