### PR TITLE
Update pointer class for export masks

### DIFF
--- a/pwem/protocols/protocol_export/protocol_export_DB.py
+++ b/pwem/protocols/protocol_export/protocol_export_DB.py
@@ -117,7 +117,7 @@ class ProtExportDataBases(EMProtocol):
                            'masks to export.')
         form.addParam('exportMasks', params.MultiPointerParam, label="Masks to export",
                       allowsNull=True, condition='masksToExport == True',
-                      pointerClass='Mask',
+                      pointerClass='VolumeMask',
                       help='These mask will be exported using mrc format')
         form.addParam('exportAtomStruct', params.PointerParam,
                       label="Atomic structure to export", allowsNull=True,


### PR DESCRIPTION
Changed pointer class for "export masks" from 'Mask' to 'VolumeMask'. Both classes exist but at least "import masks" creates volumeMasks not masks