### PR TITLE
Fix column creation in starfile DAO for empty tables

### DIFF
--- a/pwem/viewers/mdviewer/star_dao.py
+++ b/pwem/viewers/mdviewer/star_dao.py
@@ -148,8 +148,14 @@ class StarFile(IDAO):
         """Create the table structure"""
         logger.debug("Creating the table columns...")
         colNames = self._labels[table.getName()]
-        values = self._tableData[table.getName()][0]
-        table.createColumns(colNames, values)
+        data = self._tableData[table.getName()]
+        
+        if len(data) > 0:
+            firstRow = data[0]
+        else:
+            firstRow = ['']*len(colNames)
+        
+        table.createColumns(colNames, firstRow)
         table.setAlias(table.getAlias())
 
     def _findLabelLine(self):


### PR DESCRIPTION
Fixes these types of errors when viewing metadata files created by Relion:
```
Traceback (most recent call last):
  File "/home/olauzirika/miniconda3/envs/scipion3/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/olauzirika/miniconda3/envs/scipion3/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/__main__.py", line 94, in <module>
    main()
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/__main__.py", line 90, in main
    objectManager.open(args)
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/model/object_manager.py", line 94, in open
    self._gui = QTMetadataViewer(fileName=self._fileName,
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/gui/qt/qtviewer.py", line 1472, in __init__
    self.tableName = self.objectManager.getTableFromAlias(self.tableNames[0]).getName()
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/model/object_manager.py", line 312, in getTableFromAlias
    return self.getTable(table.getName())
  File "/home/olauzirika/software/scipion3/plugins/metadata-viewer/metadataviewer/model/object_manager.py", line 300, in getTable
    self._dao.fillTable(table, self)
  File "/home/olauzirika/software/scipion3/core/scipion-em/pwem/viewers/mdviewer/star_dao.py", line 59, in fillTable
    self._loadStarFileInfo(table)
  File "/home/olauzirika/software/scipion3/core/scipion-em/pwem/viewers/mdviewer/star_dao.py", line 151, in _loadStarFileInfo
    values = self._tableData[table.getName()][0]
IndexError: list index out of range
```