### PR TITLE
When continue, check that there are micrographs in the list

### DIFF
--- a/pwem/protocols/protocol_particles_picking.py
+++ b/pwem/protocols/protocol_particles_picking.py
@@ -283,11 +283,12 @@ class ProtParticlePickingAuto(ProtParticlePicking):
                 self.info("Picking micrograph: %s " % micFn)
                 micList.append(mic)
 
-        self._pickMicrographList(micList, *args)
+        if len(micList) > 0:
+            self._pickMicrographList(micList, *args)
 
-        for mic in micList:
-            # Mark this mic as finished
-            open(self._getMicDone(mic), 'w').close()
+            for mic in micList:
+                # Mark this mic as finished
+                open(self._getMicDone(mic), 'w').close()
 
     def _pickMicrographList(self, micList, *args):
         """ This function can be implemented by subclasses if it is a more


### PR DESCRIPTION
Do not enter the _pickMicrographList function if the micList to pick is empty