### PR TITLE
Rm chimera flatpak

### DIFF
--- a/pwem/convert/symmetry.py
+++ b/pwem/convert/symmetry.py
@@ -132,7 +132,8 @@ def _invertMatrix(tf):
     tf = np.array(tf)
     r = tf[:, :3]
     t = tf[:, 3]
-    tfinv = np.zeros((3, 4), np.float)
+    #tfinv = np.zeros((3, 4), np.float)
+    tfinv = np.zeros((3, 4), float)
     rinv = tfinv[:, :3]
     tinv = tfinv[:, 3]
     rinv[:, :] = matrix_inverse(r)

--- a/pwem/protocols/protocol_import/volumes.py
+++ b/pwem/protocols/protocol_import/volumes.py
@@ -402,13 +402,19 @@ Format may be PDB or MMCIF"""
 
         baseName = basename(atomStructPath)
         localPath = abspath(self._getExtraPath(baseName))
-
         chimeraPlugin = self.__getChimeraPlugin()
         if chimeraPlugin and not self.skipChimera.get():
             localCIFPath = localPath[:-4] + ".cif"
             try:
+                cmdPath = abspath(self._getExtraPath("command.cxc"))
                 localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
-                args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
+                f = open(cmdPath, "w")
+                f.write(f"open {atomStructPath}\n")
+                f.write(f"save {localPath}\n")
+                f.write("exit\n")
+                f.close()
+                # localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
+                args = f'--nogui --script {cmdPath}'
                 chimeraPlugin.runChimeraProgram(chimeraPlugin.getProgram(), args)
             except Exception as e:
                 logger.warning(f"Normal ChimeraX conversion failed: {e}")


### PR DESCRIPTION
we use to call chimera with arguments  like :
``` 
'--nogui --cmd "open {atomStructPath}; save {localPath}; exit
```
but new flatpak version does not accept them, instead a proepr script needs to be created
```
+                cmdPath = abspath(self._getExtraPath("command.cxc"))
                 localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
-                args = f'--nogui --cmd "open {atomStructPath}; save {localPath}; exit"'
+                f = open(cmdPath, "w")
+                f.write(f"open {atomStructPath}\n")
+                f.write(f"save {localPath}\n")
+                f.write("exit\n")
+                f.close()
+                # localPath = localPath[:-4] + localPath[-4:].replace(".pdb", ".cif")
+                args = f'--nogui --script {cmdPath}'
```