### PR TITLE
FSC object: Add precision parameter to calculateResolution method

### DIFF
--- a/pwem/objects/data.py
+++ b/pwem/objects/data.py
@@ -2780,7 +2780,7 @@ class FSC(EMObject):
         self._x.set(xData)
         self._y.set(yData)
 
-    def calculateResolution(self, threshold=0.143):
+    def calculateResolution(self, threshold=0.143, precision=4):
         """
         Calculate the FSC resolution value
         """
@@ -2793,7 +2793,7 @@ class FSC(EMObject):
                 below_fsc = float(self._y[i])
                 break
         resolution = below_res - ((threshold - below_fsc) / (above_fsc - below_fsc) * (below_res - above_res))
-        return "{0:.1f}".format(1 / resolution)
+        return f"{1 / resolution:.{precision}f}"
 
 
 class SetOfFSCs(EMSet):


### PR DESCRIPTION
It's nice to be able to control the precision with which this is called... Also .1 precision for FSC by default is sub-optimal so increased to 4 by default.